### PR TITLE
Fix approval buttons

### DIFF
--- a/src/components/pages/Mint/BassetInput.tsx
+++ b/src/components/pages/Mint/BassetInput.tsx
@@ -143,8 +143,8 @@ export const BassetInput: FC<Props> = ({
   );
 
   const needsUnlock = useMemo<boolean>(
-    () => allowance?.[address]?.lte(0) || false,
-    [address, allowance],
+    () => (amount.exact && allowance?.[address]?.lt(amount.exact)) || false,
+    [address, allowance, amount],
   );
 
   useEffect(() => {
@@ -202,7 +202,7 @@ export const BassetInput: FC<Props> = ({
       </Rows>
       <ValidationRow>
         {needsUnlock ? (
-          <ApproveButton size={Size.s} onClick={unlock}>
+          <ApproveButton size={Size.s} onClick={unlock} type="button">
             Approve
           </ApproveButton>
         ) : null}

--- a/src/components/pages/Mint/index.tsx
+++ b/src/components/pages/Mint/index.tsx
@@ -174,12 +174,12 @@ export const Mint: FC<{}> = () => {
 
   const handleUnlock = useCallback(
     (address: string): void => {
-      if (!signer) return;
+      if (!(signer && mUsdAddress)) return;
 
       const tokenContract = Erc20Factory.connect(address, signer);
 
       tokenContract.totalSupply().then(totalSupply => {
-        const manifest = {
+        const manifest: SendTxManifest<Interfaces.ERC20, 'approve'> = {
           iface: tokenContract,
           fn: 'approve',
           args: [mUsdAddress, totalSupply],

--- a/src/components/pages/Save/index.tsx
+++ b/src/components/pages/Save/index.tsx
@@ -154,7 +154,7 @@ export const Save: FC<{}> = () => {
       !!(
         transactionType === TransactionType.Deposit &&
         inputAmount &&
-        mUsdSavings?.allowance?.lte(inputAmount)
+        mUsdSavings?.allowance?.lt(inputAmount)
       ),
     [transactionType, inputAmount, mUsdSavings],
   );

--- a/src/components/pages/Swap/index.tsx
+++ b/src/components/pages/Swap/index.tsx
@@ -64,7 +64,7 @@ export const Swap: FC<{}> = () => {
         input.token.address &&
         input.amount.exact &&
         outputToken.allowance &&
-        outputToken.allowance[input.token.address]?.lte(input.amount.exact)
+        outputToken.allowance[input.token.address]?.lt(input.amount.exact)
       ),
     [mode, input, outputToken],
   );
@@ -344,7 +344,11 @@ export const Swap: FC<{}> = () => {
                 <>
                   <P size={1}>
                     This includes a redemption fee of{' '}
-                    <CountUp end={parseFloat(feeAmountSimple)} decimals={4} suffix=" mUSD" />
+                    <CountUp
+                      end={parseFloat(feeAmountSimple)}
+                      decimals={4}
+                      suffix=" mUSD"
+                    />
                     .
                   </P>
                   <P size={1}>


### PR DESCRIPTION
* Adjust the logic for checking whether tokens need approval such that the spend amount <= approval amount
* Add missing `type="button"` to the approval button so that it doesn't submit the whole form