### PR TITLE
Use long-polling for mUSD data

### DIFF
--- a/src/components/wallet/HistoricTransactions.tsx
+++ b/src/components/wallet/HistoricTransactions.tsx
@@ -4,9 +4,9 @@ import { BigNumber } from 'ethers/utils';
 import { useOrderedHistoricTransactions } from '../../context/TransactionsProvider';
 import { ContractNames, HistoricTransaction } from '../../types';
 import { EtherscanLink } from '../core/EtherscanLink';
-import { MassetQuery } from '../../graphql/generated';
+import { MassetData } from '../../context/DataProvider/types';
 import { useKnownAddress } from '../../context/DataProvider/KnownAddressProvider';
-import { useMusdQuery } from '../../context/DataProvider/DataProvider';
+import { useMusdData } from '../../context/DataProvider/DataProvider';
 import { formatExactAmount } from '../../web3/amounts';
 import { EMOJIS } from '../../web3/constants';
 import { List, ListItem } from '../core/List';
@@ -82,7 +82,7 @@ const getHistoricTransactionDescription = (
   {
     mUSDSavingsAddress,
     mUSD,
-  }: { mUSD: MassetQuery['masset']; mUSDSavingsAddress: string | null },
+  }: { mUSD: MassetData; mUSDSavingsAddress: string | null },
 ): JSX.Element => {
   if (!mUSD) return LOADING;
 
@@ -136,8 +136,8 @@ const getHistoricTransactionDescription = (
           values: { mAssetQuantity, bAsset, bAssetQuantity },
         },
       ] = logs;
-      const bAssetToken = mUSD.basket.bassets.find(
-        b => b.id === bAsset.toLowerCase(),
+      const bAssetToken = mUSD.bAssets?.find(
+        b => b.address === bAsset.toLowerCase(),
       );
       if (!bAssetToken) return LOADING;
 
@@ -184,11 +184,11 @@ const getHistoricTransactionDescription = (
       const {
         values: { input, output, outputAmount },
       } = logs[logs.length - 1];
-      const inputBasset = mUSD.basket.bassets.find(
-        b => b.id === input.toLowerCase(),
+      const inputBasset = mUSD.bAssets.find(
+        b => b.address === input.toLowerCase(),
       );
-      const outputBasset = mUSD.basket.bassets.find(
-        b => b.id === output.toLowerCase(),
+      const outputBasset = mUSD.bAssets.find(
+        b => b.address === output.toLowerCase(),
       );
       if (!inputBasset || !outputBasset) return LOADING;
 
@@ -217,9 +217,7 @@ const getHistoricTransactionDescription = (
 
       const bassetTokens = bAssets
         .map((address: string) =>
-          mUSD.basket.bassets.find(
-            b => b.token.address === address.toLowerCase(),
-          ),
+          mUSD.bAssets.find(b => b.address === address.toLowerCase()),
         )
         .filter(Boolean);
 
@@ -277,7 +275,7 @@ const getHistoricTransactionDescription = (
 
 const HistoricTx: FC<{
   tx: HistoricTransaction;
-  mUSD: MassetQuery['masset'];
+  mUSD: MassetData;
   mUSDSavingsAddress: string | null;
 }> = ({ tx, mUSDSavingsAddress, mUSD }) => {
   const { description, icon } = useMemo(() => {
@@ -305,8 +303,7 @@ const HistoricTx: FC<{
 
 export const HistoricTransactions: FC<{}> = () => {
   const historic = useOrderedHistoricTransactions();
-  const musdQuery = useMusdQuery();
-  const mUSD = musdQuery.data?.masset || null;
+  const mUSD = useMusdData();
   const mUSDSavingsAddress = useKnownAddress(ContractNames.mUSDSavings);
 
   return (

--- a/src/context/DataProvider/DataProvider.tsx
+++ b/src/context/DataProvider/DataProvider.tsx
@@ -8,31 +8,27 @@ import React, {
   useReducer,
 } from 'react';
 import { BigNumber, parseUnits } from 'ethers/utils';
-import { Action, Actions, BassetData, State } from './types';
 import { ContractNames } from '../../types';
 import { useToken, useTokensState } from './TokensProvider';
 import {
   SavingsContractQuery,
-  useMassetQuery,
-  useMassetSubSubscription,
   useSavingsContractDataSubscription,
+  useMassetQuery,
 } from '../../graphql/generated';
 import { useKnownAddress } from './KnownAddressProvider';
 import { EXP_SCALE, RATIO_SCALE } from '../../web3/constants';
+import { Action, Actions, BassetData, State } from './types';
 
-export const useMusdQuery = (): ReturnType<typeof useMassetQuery> => {
+export const useMusdSubscription = (): ReturnType<typeof useMassetQuery> => {
   const address = useKnownAddress(ContractNames.mUSD);
+
+  // We're using a long-polling query because subscriptions don't seem to be
+  // re-run when derived or nested fields change.
+  // See https://github.com/graphprotocol/graph-node/issues/1398
   return useMassetQuery({
     variables: { id: address as string },
     skip: !address,
-  });
-};
-
-export const useMusdSubscription = (): ReturnType<typeof useMassetSubSubscription> => {
-  const address = useKnownAddress(ContractNames.mUSD);
-  return useMassetSubSubscription({
-    variables: { id: address as string },
-    skip: !address,
+    pollInterval: 15000,
   });
 };
 

--- a/src/context/DataProvider/types.ts
+++ b/src/context/DataProvider/types.ts
@@ -1,10 +1,5 @@
 import { BigNumber } from 'ethers/utils';
-import {
-  Masset,
-  Basset,
-  MassetSubSubscription,
-  Basket,
-} from '../../graphql/generated';
+import { Masset, Basset, MassetQuery, Basket } from '../../graphql/generated';
 import {
   TokenDetailsWithBalance,
   State as TokensState,
@@ -49,6 +44,6 @@ export enum Actions {
 export type Action =
   | {
       type: Actions.UpdateMassetData;
-      payload: { data: MassetSubSubscription | undefined; loading: boolean };
+      payload: { data?: MassetQuery; loading: boolean };
     }
   | { type: Actions.UpdateTokens; payload: TokensState };

--- a/src/graphql/generated.tsx
+++ b/src/graphql/generated.tsx
@@ -1155,19 +1155,19 @@ export type SavingsContractQuery = { savingsContracts: Array<(
     & { exchangeRates: Array<Pick<ExchangeRate, 'id'>> }
   )> };
 
-export type TokenSubSubscriptionVariables = {
+export type TokensSubscriptionVariables = {
+  ids: Array<Scalars['ID']>;
+};
+
+
+export type TokensSubscription = { tokens: Array<TokenDetailsFragment> };
+
+export type TokenSubscriptionVariables = {
   id: Scalars['ID'];
 };
 
 
-export type TokenSubSubscription = { token?: Maybe<Pick<Token, 'id' | 'symbol' | 'address'>> };
-
-export type MassetSubSubscriptionVariables = {
-  id: Scalars['ID'];
-};
-
-
-export type MassetSubSubscription = { masset?: Maybe<MassetAllFragment> };
+export type TokenSubscription = { token?: Maybe<TokenDetailsFragment> };
 
 export type CreditBalancesSubscriptionVariables = {
   account: Scalars['ID'];
@@ -1473,66 +1473,64 @@ export function useSavingsContractLazyQuery(baseOptions?: ApolloReactHooks.LazyQ
 export type SavingsContractQueryHookResult = ReturnType<typeof useSavingsContractQuery>;
 export type SavingsContractLazyQueryHookResult = ReturnType<typeof useSavingsContractLazyQuery>;
 export type SavingsContractQueryResult = ApolloReactCommon.QueryResult<SavingsContractQuery, SavingsContractQueryVariables>;
-export const TokenSubDocument = gql`
-    subscription TokenSub($id: ID!) {
+export const TokensDocument = gql`
+    subscription Tokens($ids: [ID!]!) {
+  tokens(where: {id_in: $ids}) {
+    ...TokenDetails
+  }
+}
+    ${TokenDetailsFragmentDoc}`;
+
+/**
+ * __useTokensSubscription__
+ *
+ * To run a query within a React component, call `useTokensSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useTokensSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTokensSubscription({
+ *   variables: {
+ *      ids: // value for 'ids'
+ *   },
+ * });
+ */
+export function useTokensSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TokensSubscription, TokensSubscriptionVariables>) {
+        return ApolloReactHooks.useSubscription<TokensSubscription, TokensSubscriptionVariables>(TokensDocument, baseOptions);
+      }
+export type TokensSubscriptionHookResult = ReturnType<typeof useTokensSubscription>;
+export type TokensSubscriptionResult = ApolloReactCommon.SubscriptionResult<TokensSubscription>;
+export const TokenDocument = gql`
+    subscription Token($id: ID!) {
   token(id: $id) {
-    id
-    symbol
-    address
+    ...TokenDetails
   }
 }
-    `;
+    ${TokenDetailsFragmentDoc}`;
 
 /**
- * __useTokenSubSubscription__
+ * __useTokenSubscription__
  *
- * To run a query within a React component, call `useTokenSubSubscription` and pass it any options that fit your needs.
- * When your component renders, `useTokenSubSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTokenSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useTokenSubscription` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTokenSubSubscription({
+ * const { data, loading, error } = useTokenSubscription({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useTokenSubSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TokenSubSubscription, TokenSubSubscriptionVariables>) {
-        return ApolloReactHooks.useSubscription<TokenSubSubscription, TokenSubSubscriptionVariables>(TokenSubDocument, baseOptions);
+export function useTokenSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TokenSubscription, TokenSubscriptionVariables>) {
+        return ApolloReactHooks.useSubscription<TokenSubscription, TokenSubscriptionVariables>(TokenDocument, baseOptions);
       }
-export type TokenSubSubscriptionHookResult = ReturnType<typeof useTokenSubSubscription>;
-export type TokenSubSubscriptionResult = ApolloReactCommon.SubscriptionResult<TokenSubSubscription>;
-export const MassetSubDocument = gql`
-    subscription MassetSub($id: ID!) {
-  masset(id: $id) {
-    ...MassetAll
-  }
-}
-    ${MassetAllFragmentDoc}`;
-
-/**
- * __useMassetSubSubscription__
- *
- * To run a query within a React component, call `useMassetSubSubscription` and pass it any options that fit your needs.
- * When your component renders, `useMassetSubSubscription` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useMassetSubSubscription({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useMassetSubSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<MassetSubSubscription, MassetSubSubscriptionVariables>) {
-        return ApolloReactHooks.useSubscription<MassetSubSubscription, MassetSubSubscriptionVariables>(MassetSubDocument, baseOptions);
-      }
-export type MassetSubSubscriptionHookResult = ReturnType<typeof useMassetSubSubscription>;
-export type MassetSubSubscriptionResult = ApolloReactCommon.SubscriptionResult<MassetSubSubscription>;
+export type TokenSubscriptionHookResult = ReturnType<typeof useTokenSubscription>;
+export type TokenSubscriptionResult = ApolloReactCommon.SubscriptionResult<TokenSubscription>;
 export const CreditBalancesDocument = gql`
     subscription CreditBalances($account: ID!) {
   account(id: $account) {

--- a/src/graphql/subscription.graphql
+++ b/src/graphql/subscription.graphql
@@ -1,16 +1,8 @@
 # import './fragments.graphql'
 
-subscription TokenSub($id: ID!) {
+subscription Token($id: ID!) {
   token(id: $id) {
-    id
-    symbol
-    address
-  }
-}
-
-subscription MassetSub($id: ID!) {
-  masset(id: $id) {
-    ...MassetAll
+    ...TokenDetails
   }
 }
 


### PR DESCRIPTION
* Use long-polling for the mUSD data, because the subscription does not appear to update for nested fields with different entities.
* Remove `useMusdQuery` and replace it with `useMusdData` in order to get the same data everywhere.
* Remove unused `TokenSub` subscription.