### PR TITLE
Minor tweaks

### DIFF
--- a/src/components/forms/ToggleInput.tsx
+++ b/src/components/forms/ToggleInput.tsx
@@ -6,6 +6,8 @@ interface Props {
   onClick(): void;
   checked: boolean;
   disabled?: boolean;
+  enabledColor?: string;
+  disabledColor?: string;
 }
 
 const Circle = styled.span`
@@ -21,14 +23,30 @@ const Circle = styled.span`
   box-shadow: 0 0 2px 0 rgba(10, 10, 10, 0.29);
 `;
 
-const Toggle = styled.span<{ checked: boolean; disabled?: boolean }>`
+const Container = styled(UnstyledButton)`
+  display: flex;
+  align-items: center;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  padding: 0;
+`;
+
+const Toggle = styled.span<{
+  checked: boolean;
+  disabled?: boolean;
+  enabledColor?: string;
+  disabledColor?: string;
+}>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 40px;
   height: 20px;
-  background: ${({ checked, theme }) =>
-    checked ? theme.color.green : theme.color.blackTransparent};
+  background: ${({
+    checked,
+    theme,
+    enabledColor = theme.color.green,
+    disabledColor = theme.color.blackTransparent,
+  }) => (checked ? enabledColor : disabledColor)};
   border-radius: 40px;
   position: relative;
   transition: background-color 0.2s;
@@ -43,16 +61,20 @@ const Toggle = styled.span<{ checked: boolean; disabled?: boolean }>`
   }
 `;
 
-const Container = styled(UnstyledButton)`
-  display: flex;
-  align-items: center;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  padding: 0;
-`;
-
-export const ToggleInput: FC<Props> = ({ onClick, checked, disabled }) => (
+export const ToggleInput: FC<Props> = ({
+  onClick,
+  checked,
+  disabled,
+  disabledColor,
+  enabledColor,
+}) => (
   <Container onClick={onClick} type="button" disabled={disabled}>
-    <Toggle checked={checked} disabled={disabled}>
+    <Toggle
+      checked={checked}
+      disabled={disabled}
+      enabledColor={enabledColor}
+      disabledColor={disabledColor}
+    >
       <Circle />
     </Toggle>
   </Container>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo } from 'react';
 import styled from 'styled-components';
 import { A, getWorkingPath } from 'hookrouter';
+import { useCollapseWallet } from '../../context/AppProvider';
 import { FontSize, ViewportWidth } from '../../theme';
 
 interface NavItem {
@@ -82,22 +83,27 @@ const navItems: NavItem[] = [
 export const Navigation: FC<{ walletExpanded: boolean }> = ({
   walletExpanded,
 }) => {
+  const collapseWallet = useCollapseWallet();
   const activePath = getWorkingPath('');
   const items: (NavItem & { active: boolean })[] = useMemo(
     () =>
-      walletExpanded
-        ? [{ title: 'Account', active: true }]
-        : navItems.map(item => ({
-            ...item,
-            active: activePath === item.path,
-          })),
+      navItems.map(item => ({
+        ...item,
+        active: !walletExpanded && activePath === item.path,
+      })),
     [activePath, walletExpanded],
   );
+
   return (
     <Container>
       <List>
         {items.map(({ title, path, active }) => (
-          <Item key={title} active={active} inverted={walletExpanded}>
+          <Item
+            key={title}
+            active={active}
+            inverted={walletExpanded}
+            onClick={collapseWallet}
+          >
             {path ? <A href={path}>{title}</A> : <span>{title}</span>}
           </Item>
         ))}

--- a/src/components/pages/Save/index.tsx
+++ b/src/components/pages/Save/index.tsx
@@ -19,17 +19,17 @@ import {
 } from '../../../context/DataProvider/DataProvider';
 import { useTokenWithBalance } from '../../../context/DataProvider/TokensProvider';
 import { Interfaces, SendTxManifest } from '../../../types';
-import { Button } from '../../core/Button';
 import { H3, P } from '../../core/Typography';
 import { CountUp } from '../../core/CountUp';
 import { MUSDIconTransparent } from '../../icons/TokenIcon';
-import { FontSize, Size } from '../../../theme';
+import { FontSize, Size, Color } from '../../../theme';
 import { useSendTransaction } from '../../../context/TransactionsProvider';
 import {
   useMusdContract,
   useSavingsContract,
 } from '../../../context/DataProvider/ContractsProvider';
 import { TransactionDetailsDropdown } from '../../forms/TransactionDetailsDropdown';
+import { ToggleInput } from '../../forms/ToggleInput';
 import { formatExactAmount } from '../../../web3/amounts';
 import {
   useApy,
@@ -124,11 +124,6 @@ const TransactionTypeRow = styled(FormRow)`
   > * {
     padding: 0 8px;
   }
-`;
-
-const TransactionTypeButton = styled(Button)`
-  opacity: ${({ disabled }) =>
-    disabled ? '1' : '0.3'}; // disabled == selected
 `;
 
 /**
@@ -385,13 +380,13 @@ export const Save: FC<{}> = () => {
     sendTransaction(manifest);
   }, [mUsdToken, savingsContractAddress, sendTransaction, mUsdContract]);
 
-  const handleDepositButton = useCallback(() => {
-    setTransactionType(TransactionType.Deposit);
-  }, [setTransactionType]);
-
-  const handleWithdrawButton = useCallback(() => {
-    setTransactionType(TransactionType.Withdraw);
-  }, [setTransactionType]);
+  const toggleTransactionType = useCallback(() => {
+    setTransactionType(
+      transactionType === TransactionType.Deposit
+        ? TransactionType.Withdraw
+        : TransactionType.Deposit,
+    );
+  }, [setTransactionType, transactionType]);
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -437,23 +432,14 @@ export const Save: FC<{}> = () => {
         </div>
       </InfoRow>
       <TransactionTypeRow>
-        <TransactionTypeButton
-          type="button"
-          size={Size.l}
-          disabled={transactionType === TransactionType.Deposit}
-          onClick={handleDepositButton}
-        >
-          Deposit
-        </TransactionTypeButton>
-        <div>or</div>
-        <TransactionTypeButton
-          type="button"
-          size={Size.l}
-          disabled={transactionType === TransactionType.Withdraw}
-          onClick={handleWithdrawButton}
-        >
-          Withdraw
-        </TransactionTypeButton>
+        <div>Deposit</div>
+        <ToggleInput
+          onClick={toggleTransactionType}
+          checked={transactionType === TransactionType.Withdraw}
+          enabledColor={Color.blue}
+          disabledColor={Color.green}
+        />
+        <div>Withdraw</div>
       </TransactionTypeRow>
       <FormRow>
         <H3>

--- a/src/web3/connectors.ts
+++ b/src/web3/connectors.ts
@@ -31,9 +31,9 @@ export const getConnectors = (chainId: number): Connectors => {
       return {
         injected,
         portis,
-        walletlink,
         squarelink,
         fortmatic: { apiKey: process.env.REACT_APP_FORTMATIC_API_KEY_MAINNET },
+        // walletlink,
         // walletconnect,
         // torus: {
         //   ...torus,


### PR DESCRIPTION
* Use regular navigation items when the wallet is expanded; clicking on them collapses the wallet and navigates to the selected item
* Disable walletlink (for now)
* Use a toggle for the save transaction type, and give it blue/green colours