### PR TITLE
Implement correct compounding APY calcs

### DIFF
--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -90,11 +90,13 @@ export const SaveInfo: FC<{}> = () => {
   );
 
   const savingsBalance = useSavingsBalance(account);
+  const clampedBalance =
+    savingsBalance?.simple || 0 > 500 ? 500 : savingsBalance?.simple || 0;
   const savingsBalanceIncreasing = useIncreasingNumber(
     savingsBalance.simple,
     // TODO - re-introduce real APY after it settles down
     // ((savingsBalance.simple || 0) * (apyPercentage || 10)) /
-    ((savingsBalance.simple || 0) * 10) / 100 / 365 / 24 / 60 / 60 / 10,
+    (clampedBalance * 10) / 100 / 365 / 24 / 60 / 60 / 10,
     100,
   );
 

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -130,20 +130,15 @@ export const SaveInfo: FC<{}> = () => {
           ) : (
             <Skeleton />
           )}
-          {apyPercentage && apyPercentage > 25 ? (
-            <InfoMsg>
-              <a
-                href="https://docs.mstable.org/mstable-assets/massets/native-interest-rate#how-is-the-24h-apy-calculated"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                APY is an average over the past 24 hours.
-              </a>{' '}
-              APY is currently artificially high due to the initial growth phase
-              of mUSD and might not be representative; this should normalise
-              shortly.
-            </InfoMsg>
-          ) : null}
+          <InfoMsg>
+            <a
+              href="https://docs.mstable.org/mstable-assets/massets/native-interest-rate#how-is-the-24h-apy-calculated"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              APY is an average over the past 24 hours.
+            </a>
+          </InfoMsg>
         </div>
         <div>
           <H3 borderTop>Total mUSD supply</H3>

--- a/src/components/pages/Swap/index.tsx
+++ b/src/components/pages/Swap/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect } from 'react';
 import { useWallet } from 'use-wallet';
 import { BigNumber } from 'ethers/utils';
+import { MusdStats } from '../../stats/MusdStats';
 
 import {
   FormProvider,
@@ -82,6 +83,7 @@ export const Swap: FC<{}> = () => (
   <SwapProvider>
     <FormProvider>
       <SwapForm />
+      <MusdStats />
     </FormProvider>
   </SwapProvider>
 );

--- a/src/web3/__tests__/calculateApy.ts
+++ b/src/web3/__tests__/calculateApy.ts
@@ -17,6 +17,7 @@ describe('calculateAPY', () => {
     expect(formatUnits(result, 16)).toBe('0.0');
   });
 
+  // ~0.1% increase per day, linear = 36.5%, compounded = 39.3%
   test('increase over 24 hours', () => {
     const result = calculateApy(
       {
@@ -25,13 +26,30 @@ describe('calculateAPY', () => {
       },
       {
         timestamp: 60 * 60 * 24,
-        exchangeRate: '1.2',
+        exchangeRate: '1.101',
       },
     );
 
-    expect(formatUnits(result, 16)).toBe('3318.2202235084797732');
+    expect(formatUnits(result, 16)).toBe('39.32894285');
   });
 
+  // ~0.45% increase per day, linear = 164%, compounded = 423.4%
+  test('increase over 24 hours', () => {
+    const result = calculateApy(
+      {
+        timestamp: 0,
+        exchangeRate: '1.1',
+      },
+      {
+        timestamp: 24 * 60 * 60,
+        exchangeRate: '1.105',
+      },
+    );
+
+    expect(formatUnits(result, 16)).toBe('423.48156844');
+  });
+
+  // ~0.1% increase per 12h, linear = 73%, compounded = 94%
   test('increase over 12 hours', () => {
     const result = calculateApy(
       {
@@ -40,10 +58,10 @@ describe('calculateAPY', () => {
       },
       {
         timestamp: 12 * 60 * 60,
-        exchangeRate: '1.2',
+        exchangeRate: '1.101',
       },
     );
 
-    expect(formatUnits(result, 16)).toBe('6636.3636363636370206');
+    expect(formatUnits(result, 16)).toBe('94.12554315');
   });
 });

--- a/src/web3/hooks.ts
+++ b/src/web3/hooks.ts
@@ -159,16 +159,16 @@ export const calculateApy = (
   const portionOfYear = timeDiff.mul(SCALE).div(YEAR);
   const portionsInYear = SCALE.div(portionOfYear);
   const rateDecimals = parseExactAmount(SCALE.add(rateDiff), 18);
-
   if (rateDecimals.simple) {
     const x = new FractionalBigNumber(rateDecimals.simple.toString());
-    const diff = x.pow(new FractionalBigNumber(portionsInYear.toString()));
+    const diff = x
+      .pow(new FractionalBigNumber(portionsInYear.toString()))
+      .decimalPlaces(10);
     const parsed = parseAmount(diff.toString(), 18);
     return parsed.exact?.sub(SCALE) || new BigNumber(0);
   }
   return new BigNumber(0);
 };
-
 export const useApy = (): BigNumber | null => {
   const latestSub = useLatestExchangeRateSubscription();
   const latest = latestSub.data?.exchangeRates[0];

--- a/src/web3/hooks.ts
+++ b/src/web3/hooks.ts
@@ -3,6 +3,7 @@ import blockies from 'ethereum-blockies';
 import { useMutex } from 'react-context-mutex';
 import useInterval from '@use-it/interval';
 import { BigNumber, formatUnits, parseUnits } from 'ethers/utils';
+import { BigNumber as FractionalBigNumber } from 'bignumber.js';
 import { SavingsBalance, MassetNames } from '../types';
 import {
   ExchangeRate,
@@ -15,6 +16,7 @@ import {
 import { truncateAddress } from './strings';
 import { theme } from '../theme';
 import { SCALE } from './constants';
+import { parseExactAmount, parseAmount } from './amounts';
 
 type RateTimestamp = Pick<ExchangeRate, 'exchangeRate' | 'timestamp'>;
 
@@ -153,9 +155,18 @@ export const calculateApy = (
 
   const timeDiff = parseUnits((end.timestamp - start.timestamp).toString());
 
+  // new calc: (1+0.001)^365-1
   const portionOfYear = timeDiff.mul(SCALE).div(YEAR);
+  const portionsInYear = SCALE.div(portionOfYear);
+  const rateDecimals = parseExactAmount(SCALE.add(rateDiff), 18);
 
-  return rateDiff.mul(SCALE).div(portionOfYear);
+  if (rateDecimals.simple) {
+    const x = new FractionalBigNumber(rateDecimals.simple.toString());
+    const diff = x.pow(new FractionalBigNumber(portionsInYear.toString()));
+    const parsed = parseAmount(diff.toString(), 18);
+    return parsed.exact?.sub(SCALE) || new BigNumber(0);
+  }
+  return new BigNumber(0);
 };
 
 export const useApy = (): BigNumber | null => {


### PR DESCRIPTION
Retrospective APY calculation on the SAVE page was extrapolated incorrectly. It was calculated with a linear extrapolation, rather than compounding on a ~daily basis.

New calculation is a **conservative** extrapolation using a compounding interest function.

`((1+percentageRateChange)^(compoundIntervalCountPerYear))-1`

Where 'percentageRateChange' is the % increase in rate over the past 24 hours (e.g. 0.5%)
and 'compoundIntervalCountPerYear' is the number of those 24 hour periods in a year (365 +/- based on the actual timestamps)

Also: Clamped the notional balance increase to 10% of $500. Number goes up too fast otherwise