### PR TITLE
Support single bAsset redemption

### DIFF
--- a/src/components/pages/Mint/MintProvider.tsx
+++ b/src/components/pages/Mint/MintProvider.tsx
@@ -8,18 +8,13 @@ import React, {
   useMemo,
   useReducer,
 } from 'react';
-import {
-  BigNumber,
-  bigNumberify,
-  BigNumberish,
-  formatUnits,
-  parseUnits,
-} from 'ethers/utils';
+import { BigNumber, formatUnits, parseUnits } from 'ethers/utils';
 import { pipe } from 'ts-pipe-compose';
 
 import { useMusdData } from '../../../context/DataProvider/DataProvider';
 import { formatSimpleAmount, parseAmount } from '../../../web3/amounts';
-import { RATIO_SCALE, SCALE } from '../../../web3/constants';
+import { SCALE } from '../../../web3/constants';
+import { applyRatioMassetToBasset } from '../../../web3/ratio';
 import { Amount, TokenQuantity } from '../../../types';
 import { Action, Actions, Dispatch, Mode, State } from './types';
 import { applyValidation } from './validation';
@@ -45,14 +40,6 @@ const initialState: State = {
   valid: false,
   touched: false,
 };
-
-const applyRatioMassetToBasset = (
-  input: BigNumberish,
-  ratio: BigNumberish,
-): BigNumber =>
-  bigNumberify(input)
-    .mul(RATIO_SCALE)
-    .div(ratio);
 
 const calcOptimalBassetQuantitiesForMint = ({
   mAsset,

--- a/src/components/pages/Mint/validation.ts
+++ b/src/components/pages/Mint/validation.ts
@@ -54,21 +54,7 @@ const mintSingleValidator: StateValidator = state => {
     b => b.address === bAssetInput.address,
   );
 
-  if (
-    !(
-      bAssetInput.amount.exact &&
-      bAssetData?.status &&
-      bAssetData.maxWeight &&
-      bAssetData.ratio &&
-      bAssetData.vaultBalance &&
-      bAssetData.token.balance &&
-      bAssetData.token.allowance &&
-      bAssetData.token?.decimals &&
-      mAssetData?.token?.address &&
-      mAssetData?.token.decimals &&
-      mAssetData.token.totalSupply
-    )
-  ) {
+  if (!(bAssetInput.amount.exact && bAssetData && mAssetData?.token)) {
     return [false, Reasons.FetchingData];
   }
 

--- a/src/components/pages/Redeem/RedeemConfirm.tsx
+++ b/src/components/pages/Redeem/RedeemConfirm.tsx
@@ -4,33 +4,22 @@ import { P } from '../../core/Typography';
 import { CountUp } from '../../core/CountUp';
 
 export const RedeemConfirm: FC<{}> = () => {
-  const { bAssetOutputs, valid, mAssetData, redemption } = useRedeemState();
-
-  const bAssetsData = mAssetData?.bAssets || [];
-
-  const selectedBassets = bAssetOutputs.map(({ address, amount }) => ({
-    amount,
-    symbol: bAssetsData.find(b => b.address === address)?.token.symbol,
-  }));
+  const { valid, mAssetData, redemption, feeAmountSimple } = useRedeemState();
 
   return valid && redemption.amount.simple && mAssetData?.token.symbol ? (
     <>
       <P size={1}>
-        <span>You are redeeming </span>
-        {selectedBassets.map(({ amount, symbol }, index, arr) => (
-          <span key={symbol}>
-            <CountUp end={amount.simple || 0} /> {symbol}
-            {arr.length > 1 && index !== arr.length - 1
-              ? index === arr.length - 2
-                ? ' and '
-                : ', '
-              : null}
-          </span>
-        ))}
-        <span> with </span>
-        <span>
-          <CountUp end={redemption.amount.simple} /> {mAssetData.token.symbol}.
-        </span>
+        You are redeeming <CountUp end={redemption.amount.simple} />{' '}
+        {mAssetData.token.symbol}.
+      </P>
+      <P size={1}>
+        {feeAmountSimple ? (
+          <>
+            There is a swap fee of <CountUp end={feeAmountSimple} decimals={4} /> mUSD.
+          </>
+        ) : (
+          <>There is no swap fee for this transaction.</>
+        )}
       </P>
     </>
   ) : (

--- a/src/components/pages/Redeem/RedeemConfirm.tsx
+++ b/src/components/pages/Redeem/RedeemConfirm.tsx
@@ -2,9 +2,16 @@ import React, { FC } from 'react';
 import { useRedeemState } from './RedeemProvider';
 import { P } from '../../core/Typography';
 import { CountUp } from '../../core/CountUp';
+import { formatExactAmount } from '../../../web3/amounts';
 
 export const RedeemConfirm: FC<{}> = () => {
-  const { valid, mAssetData, redemption, feeAmountSimple } = useRedeemState();
+  const {
+    valid,
+    mAssetData,
+    redemption,
+    feeAmountSimple,
+    applyFee,
+  } = useRedeemState();
 
   return valid && redemption.amount.simple && mAssetData?.token.symbol ? (
     <>
@@ -13,9 +20,11 @@ export const RedeemConfirm: FC<{}> = () => {
         {mAssetData.token.symbol}.
       </P>
       <P size={1}>
-        {feeAmountSimple ? (
+        {applyFee && feeAmountSimple && mAssetData?.feeRate ? (
           <>
-            There is a swap fee of <CountUp end={feeAmountSimple} decimals={4} /> mUSD.
+            There is a swap fee of{' '}
+            <CountUp end={feeAmountSimple} decimals={4} /> mUSD (
+            {formatExactAmount(mAssetData?.feeRate, 16, '%')})
           </>
         ) : (
           <>There is no swap fee for this transaction.</>

--- a/src/components/pages/Redeem/RedeemInput.tsx
+++ b/src/components/pages/Redeem/RedeemInput.tsx
@@ -36,6 +36,7 @@ export const RedeemInput: FC<{}> = () => {
     mAssetData,
     mode,
     applyFee,
+    valid,
   } = useRedeemState();
   const {
     setRedemptionAmount,
@@ -60,7 +61,7 @@ export const RedeemInput: FC<{}> = () => {
       ),
     };
 
-    return applyFee
+    return applyFee && valid
       ? [
           bal,
           {
@@ -69,7 +70,7 @@ export const RedeemInput: FC<{}> = () => {
           },
         ]
       : [bal];
-  }, [token, applyFee]);
+  }, [token, applyFee, valid]);
 
   const handleSetMax = useCallback(() => {
     if (mUsdBalance) {

--- a/src/components/pages/Redeem/RedeemInput.tsx
+++ b/src/components/pages/Redeem/RedeemInput.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useCallback, useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
+import styled from 'styled-components';
 
 import { formatExactAmount } from '../../../web3/amounts';
 import { FormRow } from '../../core/Form';
@@ -7,16 +8,45 @@ import { H3 } from '../../core/Typography';
 import { Skeletons } from '../../core/Skeletons';
 import { BassetsGrid } from '../../core/Bassets';
 import { TokenAmountInput } from '../../forms/TokenAmountInput';
+import { ToggleInput } from '../../forms/ToggleInput';
 import { useRedeemDispatch, useRedeemState } from './RedeemProvider';
 import { BassetOutput } from './BassetOutput';
+import { Mode } from './types';
+
+const RedeemMode = styled.div`
+  display: flex;
+  align-items: center;
+
+  > * {
+    margin-right: 8px;
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+`;
 
 export const RedeemInput: FC<{}> = () => {
-  const { redemption, error, bAssetOutputs, mAssetData } = useRedeemState();
-  const { setRedemptionAmount, setExactRedemptionAmount } = useRedeemDispatch();
+  const {
+    redemption,
+    error,
+    bAssetOutputs,
+    mAssetData,
+    mode,
+  } = useRedeemState();
+  const {
+    setRedemptionAmount,
+    setExactRedemptionAmount,
+    toggleBassetEnabled,
+    toggleMode,
+  } = useRedeemDispatch();
 
   const { loading, token } = mAssetData || {};
   const mUsdBalance = token?.balance;
   const massetAddress = token?.address || null;
+  const isProportional = mode === Mode.RedeemMasset;
 
   const musdBalanceItem = useMemo(
     () => [
@@ -49,14 +79,23 @@ export const RedeemInput: FC<{}> = () => {
   return (
     <>
       <FormRow>
-        <H3>Send</H3>
+        <Header>
+          <H3>Send</H3>
+          <RedeemMode>
+            <ToggleInput
+              onClick={toggleMode}
+              checked={mode === Mode.RedeemMasset}
+            />
+            <span>Redeem with all stablecoins</span>
+          </RedeemMode>
+        </Header>
         {loading || !token?.address ? (
           <Skeleton />
         ) : (
           <TokenAmountInput
             name="redemption"
             tokenValue={token.address}
-            amountValue={redemption.formValue}
+            amountValue={redemption.formValue || null}
             tokenAddresses={[token.address]}
             onChangeAmount={handleSetAmount}
             onSetMax={handleSetMax}
@@ -72,8 +111,13 @@ export const RedeemInput: FC<{}> = () => {
           {loading || !massetAddress ? (
             <Skeletons skeletonCount={4} height={180} />
           ) : (
-            bAssetOutputs.map(({ address }) => (
-              <BassetOutput key={address} address={address} />
+            bAssetOutputs.map(({ address, enabled }) => (
+              <BassetOutput
+                key={address}
+                address={address}
+                handleToggle={toggleBassetEnabled}
+                toggleDisabled={isProportional || enabled}
+              />
             ))
           )}
         </BassetsGrid>

--- a/src/components/pages/Redeem/RedeemInput.tsx
+++ b/src/components/pages/Redeem/RedeemInput.tsx
@@ -73,9 +73,13 @@ export const RedeemInput: FC<{}> = () => {
 
   const handleSetMax = useCallback(() => {
     if (mUsdBalance) {
-      setExactRedemptionAmount(mUsdBalance);
+      if (mode === Mode.RedeemMasset) {
+        setExactRedemptionAmount(mUsdBalance);
+      } else if (mode === Mode.RedeemSingle) {
+        // min (balance, vaultBalance, othersOverweight)
+      }
     }
-  }, [mUsdBalance, setExactRedemptionAmount]);
+  }, [mUsdBalance, setExactRedemptionAmount, mode]);
 
   const handleSetAmount = useCallback(
     (_, amount) => {
@@ -106,7 +110,7 @@ export const RedeemInput: FC<{}> = () => {
             amountValue={redemption.formValue || null}
             tokenAddresses={[token.address]}
             onChangeAmount={handleSetAmount}
-            onSetMax={handleSetMax}
+            onSetMax={mode === Mode.RedeemMasset ? handleSetMax : undefined}
             items={items}
             tokenDisabled
             error={error}

--- a/src/components/pages/Redeem/RedeemInput.tsx
+++ b/src/components/pages/Redeem/RedeemInput.tsx
@@ -49,20 +49,27 @@ export const RedeemInput: FC<{}> = () => {
   const massetAddress = token?.address || null;
   const isProportional = mode === Mode.RedeemMasset;
 
-  const musdBalanceItem = useMemo(
-    () => [
-      {
-        label: 'Balance',
-        value: formatExactAmount(
-          token?.balance,
-          token?.decimals,
-          token?.symbol,
-          true,
-        ),
-      },
-    ],
-    [token],
-  );
+  const items = useMemo(() => {
+    const bal = {
+      label: 'Balance',
+      value: formatExactAmount(
+        token?.balance,
+        token?.decimals,
+        token?.symbol,
+        true,
+      ),
+    };
+
+    return applyFee
+      ? [
+          bal,
+          {
+            label: 'NOTE',
+            value: 'Swap fee applies (see details below)',
+          },
+        ]
+      : [bal];
+  }, [token, applyFee]);
 
   const handleSetMax = useCallback(() => {
     if (mUsdBalance) {
@@ -100,7 +107,7 @@ export const RedeemInput: FC<{}> = () => {
             tokenAddresses={[token.address]}
             onChangeAmount={handleSetAmount}
             onSetMax={handleSetMax}
-            items={musdBalanceItem}
+            items={items}
             tokenDisabled
             error={error}
           />

--- a/src/components/pages/Redeem/RedeemInput.tsx
+++ b/src/components/pages/Redeem/RedeemInput.tsx
@@ -35,6 +35,7 @@ export const RedeemInput: FC<{}> = () => {
     bAssetOutputs,
     mAssetData,
     mode,
+    applyFee,
   } = useRedeemState();
   const {
     setRedemptionAmount,
@@ -113,6 +114,8 @@ export const RedeemInput: FC<{}> = () => {
           ) : (
             bAssetOutputs.map(({ address, enabled }) => (
               <BassetOutput
+                applyFee={applyFee}
+                feeRate={mAssetData?.feeRate}
                 key={address}
                 address={address}
                 handleToggle={toggleBassetEnabled}

--- a/src/components/pages/Redeem/RedeemProvider.tsx
+++ b/src/components/pages/Redeem/RedeemProvider.tsx
@@ -115,10 +115,11 @@ const applySwapFee = (state: State): State => {
   const {
     mAssetData,
     mode,
+    bAssetOutputs,
     redemption: { amount },
   } = state;
 
-  if (mode === Mode.RedeemMasset) {
+  if (mode === Mode.RedeemMasset || !bAssetOutputs.some(b => b.enabled)) {
     return {
       ...state,
       applyFee: false,

--- a/src/components/pages/Redeem/RedeemProvider.tsx
+++ b/src/components/pages/Redeem/RedeemProvider.tsx
@@ -114,19 +114,39 @@ const updateBAssetOutputs = (state: State): State => {
 const applySwapFee = (state: State): State => {
   const {
     mAssetData,
+    mode,
     redemption: { amount },
   } = state;
+
+  if (mode === Mode.RedeemMasset) {
+    return {
+      ...state,
+      applyFee: false,
+      feeAmountSimple: 0,
+    };
+  }
 
   const nOverweightBassets =
     mAssetData?.bAssets.filter(b => b.overweight).length || 0;
 
+  const applyFee = nOverweightBassets === 0;
+
+  if (!applyFee) {
+    return {
+      ...state,
+      applyFee: false,
+      feeAmountSimple: 0,
+    };
+  }
+
   const feeAmountExact =
-    amount.exact && mAssetData?.feeRate && nOverweightBassets === 0
+    amount.exact && mAssetData?.feeRate && applyFee
       ? amount.exact.mul(mAssetData.feeRate).div(EXP_SCALE)
       : undefined;
 
   return {
     ...state,
+    applyFee: true,
     feeAmountSimple: feeAmountExact
       ? parseFloat(formatUnits(feeAmountExact, 18))
       : undefined,
@@ -232,6 +252,7 @@ const initialState: State = {
   valid: false,
   touched: false,
   mode: Mode.RedeemMasset,
+  applyFee: false,
   redemption: {
     amount: {
       simple: null,

--- a/src/components/pages/Redeem/RedeemProvider.tsx
+++ b/src/components/pages/Redeem/RedeemProvider.tsx
@@ -13,8 +13,12 @@ import { pipe } from 'ts-pipe-compose';
 
 import { BassetData } from '../../../context/DataProvider/types';
 import { useMusdData } from '../../../context/DataProvider/DataProvider';
-import { parseAmount, parseExactAmount } from '../../../web3/amounts';
-import { RATIO_SCALE, EXP_SCALE } from '../../../web3/constants';
+import {
+  formatSimpleAmount,
+  parseAmount,
+  parseExactAmount,
+} from '../../../web3/amounts';
+import { EXP_SCALE, RATIO_SCALE } from '../../../web3/constants';
 import { Amount } from '../../../types';
 import { Action, Actions, BassetOutput, Dispatch, Mode, State } from './types';
 import { applyValidation } from './validate';
@@ -35,6 +39,12 @@ const estimateRedemptionQuantities = (
   );
 
   return scaledVaults.map((vault, index) => {
+    if (totalVault.eq(0)) {
+      return {
+        exact: null,
+        simple: null,
+      };
+    }
     const percentage = vault.mul(EXP_SCALE).div(totalVault);
     const scaledAmount = percentage.mul(massetAmount).div(EXP_SCALE);
     const exact = scaledAmount
@@ -47,31 +57,84 @@ const estimateRedemptionQuantities = (
   });
 };
 
-const updateBassetAmounts = (state: State): State => {
+const updateBAssetOutputs = (state: State): State => {
   if (!state.mAssetData?.basket) return state;
 
   const {
     bAssetOutputs,
     redemption,
-    mAssetData: { bAssets: bassetsData },
+    mAssetData: { bAssets },
+    mode,
   } = state;
 
-  const redemptionAmounts = estimateRedemptionQuantities(
-    bassetsData,
-    redemption.amount.exact || new BigNumber(0),
-  );
+  if (mode === Mode.RedeemMasset) {
+    const redemptionAmounts = estimateRedemptionQuantities(
+      bAssets,
+      redemption.amount.exact || new BigNumber(0),
+    );
+
+    return {
+      ...state,
+      bAssetOutputs: bAssetOutputs.map((b, index) => ({
+        ...b,
+        amount: redemptionAmounts[index],
+        formValue:
+          formatSimpleAmount(redemptionAmounts[index].simple || 0) || undefined,
+      })),
+    };
+  }
 
   return {
     ...state,
-    bAssetOutputs: bAssetOutputs.map((b, index) => ({
-      ...b,
-      amount: redemptionAmounts[index],
-    })),
+    bAssetOutputs: bAssetOutputs.map(b => {
+      const amount = redemption.amount.simple || 0;
+      const bAssetData = bAssets.find(_b => _b.address === b.address);
+      const decimals = bAssetData?.token.decimals;
+      return {
+        ...b,
+        ...(b.enabled && decimals
+          ? {
+              // The redemption amount must be parsed for the bAsset decimals
+              amount: parseAmount(amount.toString(), decimals),
+              formValue:
+                formatSimpleAmount(redemption.amount.simple || 0) || undefined,
+            }
+          : {
+              amount: { exact: null, simple: null },
+              formValue: undefined,
+            }),
+      };
+    }),
+  };
+};
+
+/**
+ * Calculate and apply the swap fee.
+ */
+const applySwapFee = (state: State): State => {
+  const {
+    mAssetData,
+    redemption: { amount },
+  } = state;
+
+  const nOverweightBassets =
+    mAssetData?.bAssets.filter(b => b.overweight).length || 0;
+
+  const feeAmountExact =
+    amount.exact && mAssetData?.feeRate && nOverweightBassets === 0
+      ? amount.exact.mul(mAssetData.feeRate).div(EXP_SCALE)
+      : undefined;
+
+  return {
+    ...state,
+    feeAmountSimple: feeAmountExact
+      ? parseFloat(formatUnits(feeAmountExact, 18))
+      : undefined,
   };
 };
 
 const update = (state: State): State =>
-  pipe(state, updateBassetAmounts, applyValidation);
+  pipe(state, updateBAssetOutputs, applyValidation, applySwapFee);
 
 const reducer: Reducer<State, Action> = (state, action) => {
   switch (action.type) {
@@ -86,6 +149,7 @@ const reducer: Reducer<State, Action> = (state, action) => {
             : mAssetData.bAssets.map(b => ({
                 address: b.address,
                 amount: { exact: null, simple: null },
+                enabled: true,
               })) || [],
       });
     }
@@ -101,9 +165,7 @@ const reducer: Reducer<State, Action> = (state, action) => {
         ...state,
         touched: true,
         redemption: {
-          formValue: parsedAmount.simple
-            ? parsedAmount.simple.toString()
-            : null,
+          formValue: parsedAmount.simple?.toString(),
           amount: parsedAmount,
         },
       });
@@ -115,12 +177,48 @@ const reducer: Reducer<State, Action> = (state, action) => {
         ...state,
         touched: true,
         redemption: {
-          formValue,
+          formValue: formValue || undefined,
           amount: parseAmount(
             formValue,
             state.mAssetData?.token.decimals || 18,
           ),
         },
+      });
+    }
+
+    case Actions.ToggleBassetEnabled: {
+      const address = action.payload;
+
+      if (state.mode !== Mode.RedeemSingle) {
+        return state;
+      }
+
+      return update({
+        ...state,
+        bAssetOutputs: state.bAssetOutputs.map(b => ({
+          ...b,
+          enabled: b.address === address,
+        })),
+      });
+    }
+
+    case Actions.ToggleMode: {
+      // TODO redeemMulti
+      const mode =
+        state.mode === Mode.RedeemSingle
+          ? Mode.RedeemMasset
+          : Mode.RedeemSingle;
+      return update({
+        ...state,
+        mode,
+        bAssetOutputs: state.bAssetOutputs.map(b =>
+          mode === Mode.RedeemSingle
+            ? { ...b, enabled: false }
+            : {
+                ...b,
+                enabled: true,
+              },
+        ),
       });
     }
 
@@ -133,10 +231,8 @@ const initialState: State = {
   bAssetOutputs: [],
   valid: false,
   touched: false,
-  mAssetData: null,
-  mode: Mode.RedeemProportional,
+  mode: Mode.RedeemMasset,
   redemption: {
-    formValue: null,
     amount: {
       simple: null,
       exact: null,
@@ -159,6 +255,7 @@ export const RedeemProvider: FC<{}> = ({ children }) => {
     },
     [dispatch],
   );
+
   const setExactRedemptionAmount = useCallback<
     Dispatch['setExactRedemptionAmount']
   >(
@@ -167,6 +264,17 @@ export const RedeemProvider: FC<{}> = ({ children }) => {
         type: Actions.SetExactRedemptionAmount,
         payload: amount,
       });
+    },
+    [dispatch],
+  );
+
+  const toggleMode = useCallback<Dispatch['toggleMode']>(() => {
+    dispatch({ type: Actions.ToggleMode });
+  }, [dispatch]);
+
+  const toggleBassetEnabled = useCallback<Dispatch['toggleBassetEnabled']>(
+    bAsset => {
+      dispatch({ type: Actions.ToggleBassetEnabled, payload: bAsset });
     },
     [dispatch],
   );
@@ -183,8 +291,18 @@ export const RedeemProvider: FC<{}> = ({ children }) => {
     <stateCtx.Provider value={state}>
       <dispatchCtx.Provider
         value={useMemo(
-          () => ({ setRedemptionAmount, setExactRedemptionAmount }),
-          [setRedemptionAmount, setExactRedemptionAmount],
+          () => ({
+            setExactRedemptionAmount,
+            setRedemptionAmount,
+            toggleBassetEnabled,
+            toggleMode,
+          }),
+          [
+            setExactRedemptionAmount,
+            setRedemptionAmount,
+            toggleBassetEnabled,
+            toggleMode,
+          ],
         )}
       >
         {children}
@@ -197,18 +315,22 @@ export const useRedeemState = (): State => useContext(stateCtx);
 
 export const useRedeemDispatch = (): Dispatch => useContext(dispatchCtx);
 
-export const useRedeemBassetOutput = (address: string): BassetOutput | null => {
+export const useRedeemBassetOutput = (
+  address: string,
+): BassetOutput | undefined => {
   const { bAssetOutputs } = useRedeemState();
-  return useMemo(() => bAssetOutputs.find(b => b.address === address) || null, [
+  return useMemo(() => bAssetOutputs.find(b => b.address === address), [
     address,
     bAssetOutputs,
   ]);
 };
 
-export const useRedeemBassetData = (address: string): BassetData | null => {
+export const useRedeemBassetData = (
+  address: string,
+): BassetData | undefined => {
   const { mAssetData } = useRedeemState();
-  return useMemo(
-    () => mAssetData?.bAssets.find(b => b.address === address) || null,
-    [mAssetData, address],
-  );
+  return useMemo(() => mAssetData?.bAssets.find(b => b.address === address), [
+    mAssetData,
+    address,
+  ]);
 };

--- a/src/components/pages/Redeem/__tests__/validate.test.ts
+++ b/src/components/pages/Redeem/__tests__/validate.test.ts
@@ -16,6 +16,7 @@ describe('Redeem - validate', () => {
       bAssetOutputs: [] as BassetOutput[],
       redemption: { amount: { exact: null, simple: null } },
       valid: false,
+      applyFee: false,
     };
 
     test('invalid (but no errors) with untouched state', () => {
@@ -130,6 +131,7 @@ describe('Redeem - validate', () => {
       bAssetOutputs: [] as BassetOutput[],
       redemption: { amount: { exact: null, simple: null } },
       valid: false,
+      applyFee: false,
     };
 
     test('error when no token selected', () => {
@@ -240,6 +242,7 @@ describe('Redeem - validate', () => {
       ] as BassetOutput[],
       redemption: { amount: { exact: null, simple: null } },
       valid: false,
+      applyFee: false,
     };
 
     test.only('error when output amounts are not set', () => {

--- a/src/components/pages/Redeem/__tests__/validate.test.ts
+++ b/src/components/pages/Redeem/__tests__/validate.test.ts
@@ -1,0 +1,306 @@
+import { BigNumber } from 'ethers/utils';
+import { validate } from '../validate';
+import { BassetOutput, Mode, State, Reasons } from '../types';
+import { MassetData } from '../../../../context/DataProvider/types';
+import { BassetStatus } from '../../Mint/types';
+
+describe('Redeem - validate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('basket validation', () => {
+    const baseState: State = {
+      touched: false,
+      mode: Mode.RedeemSingle,
+      bAssetOutputs: [] as BassetOutput[],
+      redemption: { amount: { exact: null, simple: null } },
+      valid: false,
+    };
+
+    test('invalid (but no errors) with untouched state', () => {
+      expect(validate.applyValidation(baseState)).toMatchObject({
+        error: undefined,
+        valid: false,
+      });
+    });
+
+    test('error when basket data is not loaded', () => {
+      expect(
+        validate.applyValidation({ ...baseState, touched: true }),
+      ).toMatchObject({
+        error: Reasons.FetchingData,
+        valid: false,
+      });
+    });
+
+    test('must redeem proportionally when basket is failed', () => {
+      expect(
+        validate.applyValidation({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: { failed: true },
+            token: {},
+          } as unknown) as MassetData,
+        }),
+      ).toMatchObject({
+        error: Reasons.FetchingData,
+        valid: false,
+      });
+    });
+
+    test('must redeem proportionally when some bAssets are not normal state', () => {
+      expect(
+        validate.applyValidation({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: {},
+            token: { balance: 1 },
+            bAssets: [{ status: BassetStatus.BrokenAbovePeg }],
+          } as unknown) as MassetData,
+        }),
+      ).toMatchObject({
+        error: Reasons.MustRedeemProportionally,
+        valid: false,
+      });
+    });
+
+    test('must redeem proportionally when more than one bAsset is overweight', () => {
+      expect(
+        validate.applyValidation({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: {},
+            token: { balance: 1 },
+            bAssets: [
+              { overweight: false },
+              { overweight: true },
+              { overweight: true },
+            ],
+          } as unknown) as MassetData,
+        }),
+      ).toMatchObject({
+        error: Reasons.MustRedeemProportionally,
+        valid: false,
+      });
+    });
+
+    test('error when basket contains blacklisted asset', () => {
+      expect(
+        validate.applyValidation({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: {},
+            token: { balance: 1 },
+            bAssets: [{ status: BassetStatus.Blacklisted }],
+          } as unknown) as MassetData,
+        }),
+      ).toMatchObject({
+        error: Reasons.BasketContainsBlacklistedAsset,
+        valid: false,
+      });
+    });
+
+    test('error when undergoing recol', () => {
+      expect(
+        validate.applyValidation({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: { undergoingRecol: true },
+            token: { balance: 1 },
+            bAssets: [],
+          } as unknown) as MassetData,
+        }),
+      ).toMatchObject({
+        error: Reasons.RedemptionPausedDuringRecol,
+        valid: false,
+      });
+    });
+  });
+
+  describe('redeemSingle validation', () => {
+    const baseState: State = {
+      touched: true,
+      mode: Mode.RedeemSingle,
+      bAssetOutputs: [] as BassetOutput[],
+      redemption: { amount: { exact: null, simple: null } },
+      valid: false,
+    };
+
+    test('error when no token selected', () => {
+      expect(
+        validate.redeemSingleValidator({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: {},
+            token: { balance: 1 },
+            bAssets: [],
+          } as unknown) as MassetData,
+          bAssetOutputs: [{ enabled: false } as BassetOutput],
+        }),
+      ).toEqual([false, Reasons.NoTokenSelected]);
+    });
+
+    test('error when single overweight bAsset is not selected', () => {
+      expect(
+        validate.redeemSingleValidator({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: {},
+            token: { balance: 1 },
+            bAssets: [
+              {
+                status: BassetStatus.Normal,
+                overweight: false,
+                address: 'normal',
+              },
+              {
+                status: BassetStatus.Normal,
+                overweight: true,
+                address: 'overweight',
+              },
+            ],
+          } as unknown) as MassetData,
+          bAssetOutputs: [
+            { enabled: true, address: 'normal' },
+            { enabled: false, address: 'overweight' },
+          ] as BassetOutput[],
+        }),
+      ).toEqual([false, Reasons.MustRedeemOverweightBassets, ['overweight']]);
+    });
+
+    test('valid when single overweight bAsset is selected', () => {
+      const spy = jest.spyOn(validate, 'redemptionValidator');
+      spy.mockImplementationOnce(() => [true]);
+      expect(
+        validate.redeemSingleValidator({
+          ...baseState,
+          touched: true,
+          mAssetData: ({
+            basket: {},
+            token: { balance: 1 },
+            bAssets: [
+              {
+                status: BassetStatus.Normal,
+                overweight: false,
+                address: 'normal',
+              },
+              {
+                status: BassetStatus.Normal,
+                overweight: true,
+                address: 'overweight',
+              },
+            ],
+          } as unknown) as MassetData,
+          bAssetOutputs: [
+            { enabled: false, address: 'normal' },
+            { enabled: true, address: 'overweight' },
+          ] as BassetOutput[],
+        }),
+      ).toEqual([true]);
+    });
+  });
+
+  describe('redeemSingle/redeemMulti common validation', () => {
+    const baseState: State = {
+      touched: true,
+      mode: Mode.RedeemSingle,
+      mAssetData: ({
+        basket: {},
+        token: { balance: '1', totalSupply: '1', decimals: 18 },
+        bAssets: [
+          {
+            status: BassetStatus.Normal,
+            overweight: false,
+            address: 'normal',
+            vaultBalance: '10000',
+            token: {
+              decimals: 18,
+              totalSupply: '10000000000',
+              balance: new BigNumber(1),
+            },
+            ratio: 1,
+            maxWeight: '400000',
+          },
+        ],
+      } as unknown) as MassetData,
+      bAssetOutputs: [
+        {
+          enabled: true,
+          address: 'normal',
+          amount: { exact: null, simple: null },
+        },
+      ] as BassetOutput[],
+      redemption: { amount: { exact: null, simple: null } },
+      valid: false,
+    };
+
+    test.only('error when output amounts are not set', () => {
+      expect(
+        validate.redemptionValidator({
+          ...baseState,
+          redemption: { amount: { exact: new BigNumber(1), simple: 1 } },
+        }),
+      ).toEqual([false, Reasons.AmountMustBeSet, ['normal']]);
+    });
+
+    test('error when output amounts are zero', () => {
+      expect(
+        validate.redemptionValidator({
+          ...baseState,
+          bAssetOutputs: [
+            {
+              ...baseState.bAssetOutputs[0],
+              amount: { exact: new BigNumber(0), simple: 0 },
+            },
+          ],
+          redemption: { amount: { exact: new BigNumber(1), simple: 1 } },
+        }),
+      ).toEqual([false, Reasons.AmountMustBeGreaterThanZero, ['normal']]);
+    });
+
+    test('error when amount exceeds mAsset balance', () => {
+      expect(
+        validate.redemptionValidator({
+          ...baseState,
+          bAssetOutputs: [
+            {
+              ...baseState.bAssetOutputs[0],
+              amount: { exact: new BigNumber(10), simple: 10 },
+            },
+          ],
+          redemption: { amount: { exact: new BigNumber(10), simple: 10 } },
+        }),
+      ).toEqual([false, Reasons.AmountExceedsBalance]);
+    });
+
+    test.todo('error when vault balance exceeded');
+    test.todo('valid when vault balance is just under being exceeded');
+    test.todo('error when some overweight bAssets not enabled');
+    test.todo('valid when all overweight bAssets are enabled');
+    test.todo('error when bAssets are pushed above max weight');
+    test.todo('valid when bAssets are pushed just under max weight');
+    test.todo(
+      'must redeem proportionally when bAsset weights would become breached',
+    );
+    test.todo('valid when bAsset weights are just under being breached');
+  });
+
+  describe('redeemMasset validation', () => {
+    test.todo('error when mAsset balance is not loaded');
+    test.todo('error when amount is not set');
+    test.todo('error when amount is zero');
+    test.todo('error when amount exceeds balance');
+    test.todo('error when no token selected');
+    test.todo('error when nothing in basket to redeem');
+    test.todo('error when not enough liquidity');
+    test.todo('valid state');
+  });
+});

--- a/src/components/pages/Redeem/types.ts
+++ b/src/components/pages/Redeem/types.ts
@@ -71,6 +71,7 @@ export interface State {
   };
   touched?: boolean;
   valid: boolean;
+  applyFee: boolean;
   feeAmountSimple?: number;
 }
 

--- a/src/components/pages/Redeem/types.ts
+++ b/src/components/pages/Redeem/types.ts
@@ -2,16 +2,34 @@ import { BigNumber } from 'ethers/utils';
 import { Amount } from '../../../types';
 import { MassetData } from '../../../context/DataProvider/types';
 
+export enum Reasons {
+  AmountExceedsBalance = 'Amount exceeds balance',
+  AmountMustBeGreaterThanZero = 'Amount must be greater than zero',
+  AmountMustBeSet = 'Amount must be set',
+  BasketContainsBlacklistedAsset = 'Basket contains blacklisted asset',
+  BassetsMustRemainBelowMaxWeight = 'bAssets must remain below max weight',
+  CannotRedeemMoreBassetsThanAreInTheVault = 'Cannot redeem more bAssets than are in the vault',
+  FetchingData = 'Fetching data',
+  MustRedeemOverweightBassets = 'Redemption must use overweight bAssets',
+  MustRedeemProportionally = 'Proportional redemption is required',
+  NoTokenSelected = 'No token selected',
+  NoTokensSelected = 'No tokens selected',
+  NotEnoughLiquidity = 'Not enough liquidity',
+  NothingInTheBasketToRedeem = 'Nothing in the basket to redeem',
+  RedemptionPausedDuringRecol = 'Redemption paused during recollateralisation',
+}
+
 export enum Mode {
-  RedeemProportional,
-  // TODO later use these modes
+  RedeemMasset,
   RedeemSingle,
   RedeemMulti,
 }
 
 export enum Actions {
-  SetRedemptionAmount,
   SetExactRedemptionAmount,
+  SetRedemptionAmount,
+  ToggleBassetEnabled,
+  ToggleMode,
   UpdateMassetData,
 }
 
@@ -24,6 +42,11 @@ export type Action =
       type: Actions.SetExactRedemptionAmount;
       payload: BigNumber;
     }
+  | { type: Actions.ToggleMode }
+  | {
+      type: Actions.ToggleBassetEnabled;
+      payload: string;
+    }
   | {
       type: Actions.UpdateMassetData;
       payload: MassetData;
@@ -32,22 +55,35 @@ export type Action =
 export interface BassetOutput {
   address: string;
   amount: Amount;
+  enabled: boolean;
+  error?: string;
+  formValue?: string;
 }
 
 export interface State {
   bAssetOutputs: BassetOutput[];
   error?: string;
-  valid: boolean;
-  touched: boolean;
-  mAssetData: MassetData | null;
+  mAssetData?: MassetData;
   mode: Mode;
   redemption: {
     amount: Amount;
-    formValue: string | null;
+    formValue?: string;
   };
+  touched?: boolean;
+  valid: boolean;
+  feeAmountSimple?: number;
 }
 
 export interface Dispatch {
   setRedemptionAmount(amount: string | null): void;
   setExactRedemptionAmount(amount: BigNumber): void;
+  toggleMode(): void;
+  toggleBassetEnabled(bAsset: string): void;
 }
+
+export type ValidationResult =
+  | [boolean]
+  | [boolean, string]
+  | [boolean, string, string[]];
+
+export type StateValidator = (state: State) => ValidationResult;

--- a/src/components/pages/Redeem/validate.ts
+++ b/src/components/pages/Redeem/validate.ts
@@ -1,24 +1,373 @@
-import { State } from './types';
+/* eslint-disable @typescript-eslint/no-use-before-define */
 
-const validate = ({ redemption, mAssetData }: State): string | undefined => {
-  if (redemption.amount.exact && mAssetData?.token.balance) {
-    if (redemption.amount.exact.gt(mAssetData.token.balance)) {
-      return 'Insufficient balance';
-    }
-    if (redemption.amount.exact.eq(0)) {
-      return 'Amount must be greater than zero';
-    }
+import { BigNumber, bigNumberify, parseUnits } from 'ethers/utils';
+import { BassetData, MassetData } from '../../../context/DataProvider/types';
+import { applyRatioMassetToBasset } from '../../../web3/ratio';
+import { EXP_SCALE, RATIO_SCALE } from '../../../web3/constants';
+import { BassetStatus } from '../Mint/types';
+import { BassetOutput, Mode, Reasons, State, StateValidator } from './types';
+import { Amount } from '../../../types';
+
+// It's not possible to construct a BigNumber with `5e22`
+const WEIGHT_THRESHOLD = new BigNumber((5e20).toString()).mul(100);
+
+/**
+ * Combine bAsset output state with data from the mAsset
+ */
+const combineBassetsData = ({
+  mAssetData,
+  bAssetOutputs,
+}: State): {
+  data: BassetData;
+  output: BassetOutput;
+  vaultBalanceExact: BigNumber;
+}[] =>
+  (mAssetData?.bAssets || []).map(data => ({
+    data,
+    output: bAssetOutputs.find(b => b.address === data.address) as BassetOutput,
+    vaultBalanceExact: parseUnits(data.vaultBalance, data.token.decimals),
+  }));
+
+/**
+ * Validate redemption outputs state (not applicable for `redeemMasset`)
+ */
+const redeemOutputValidator: StateValidator = state => {
+  const { token } = state.mAssetData as NonNullable<MassetData>;
+
+  const totalVault = parseUnits(token.totalSupply, token.decimals);
+
+  const bAssets = combineBassetsData(state);
+  const enabled = bAssets.filter(b => b.output.enabled);
+
+  const amountsRequired = enabled.filter(
+    ({
+      output: {
+        amount: { exact },
+      },
+    }) => !exact,
+  );
+
+  if (amountsRequired.length > 0) {
+    return [
+      false,
+      Reasons.AmountMustBeSet,
+      amountsRequired.map(b => b.data.address),
+    ];
   }
 
-  return undefined;
+  const amountsZero = enabled.filter(({ output: { amount: { exact } } }) =>
+    (exact as NonNullable<BigNumber>).lte(0),
+  );
+
+  if (amountsZero.length > 0) {
+    return [
+      false,
+      Reasons.AmountMustBeGreaterThanZero,
+      amountsZero.map(b => b.data.address),
+    ];
+  }
+
+  const amountExceedingMassetBalance = enabled.filter(
+    ({
+      data: {
+        token: { balance },
+      },
+      output: {
+        amount: { exact },
+      },
+    }) =>
+      (exact as NonNullable<BigNumber>).gt(balance as NonNullable<BigNumber>),
+  );
+
+  if (amountExceedingMassetBalance.length > 0) {
+    return [
+      false,
+      Reasons.AmountExceedsBalance,
+      amountExceedingMassetBalance.map(b => b.data.address),
+    ];
+  }
+
+  const vaultBalancesExceeded = enabled.filter(
+    ({
+      vaultBalanceExact,
+      output: {
+        amount: { exact },
+      },
+    }) => (exact as NonNullable<BigNumber>).gt(vaultBalanceExact),
+  );
+
+  if (vaultBalancesExceeded.length > 0) {
+    return [
+      false,
+      Reasons.CannotRedeemMoreBassetsThanAreInTheVault,
+      vaultBalancesExceeded.map(b => b.data.address),
+    ];
+  }
+
+  const overweightBassetsNotEnabled = bAssets.filter(
+    b => b.data.overweight && !b.output.enabled,
+  );
+
+  if (overweightBassetsNotEnabled.length > 0) {
+    return [
+      false,
+      Reasons.MustRedeemOverweightBassets,
+      overweightBassetsNotEnabled.map(b => b.data.address),
+    ];
+  }
+
+  const ratioedRedemptionAmounts = bAssets.map(
+    ({
+      data: { ratio },
+      output: {
+        amount: { exact },
+      },
+    }) => (exact ? applyRatioMassetToBasset(exact, ratio) : new BigNumber(0)),
+  );
+
+  const newRatioedBassetVaults = bAssets.map(
+    ({ data: { ratio }, vaultBalanceExact }, index) =>
+      applyRatioMassetToBasset(vaultBalanceExact, ratio).sub(
+        ratioedRedemptionAmounts[index],
+      ),
+  );
+
+  const newTotalVault = ratioedRedemptionAmounts.reduce(
+    (_newTotalVault, amount) => _newTotalVault.sub(amount),
+    totalVault,
+  );
+
+  const maxWeightsInUnits = bAssets.map(({ data: { maxWeight } }) =>
+    newTotalVault.mul(maxWeight).div(EXP_SCALE),
+  );
+
+  const newOverweightBassets = bAssets.filter(
+    ({ data: { overweight: previouslyOverweight } }, index) => {
+      const isOverweight = newRatioedBassetVaults[index].gt(
+        maxWeightsInUnits[index],
+      );
+      return !previouslyOverweight && isOverweight;
+    },
+  );
+
+  if (newOverweightBassets.length > 0) {
+    return [
+      false,
+      Reasons.BassetsMustRemainBelowMaxWeight,
+      newOverweightBassets.map(b => b.data.address),
+    ];
+  }
+
+  const onePercentOfTotal = totalVault.mul(RATIO_SCALE).div(EXP_SCALE);
+
+  const weightBreachThreshold = onePercentOfTotal.gt(WEIGHT_THRESHOLD)
+    ? WEIGHT_THRESHOLD
+    : onePercentOfTotal;
+
+  const breachedBassets = bAssets.filter((_, index) => {
+    const lowerBound = weightBreachThreshold.gt(maxWeightsInUnits[index])
+      ? new BigNumber(0)
+      : maxWeightsInUnits[index].sub(weightBreachThreshold);
+    return (
+      newRatioedBassetVaults[index].gt(lowerBound) &&
+      newRatioedBassetVaults[index].lte(maxWeightsInUnits[index])
+    );
+  });
+
+  if (
+    breachedBassets.length > 0 &&
+    bAssets.filter(b => b.data.overweight).length === 0
+  ) {
+    return [
+      false,
+      Reasons.MustRedeemProportionally,
+      breachedBassets.map(b => b.data.address),
+    ];
+  }
+
+  return [true];
 };
 
-export const applyValidation = (state: State): State => {
-  const { touched } = state;
-  const error = touched ? validate(state) : undefined;
+/**
+ * Validate `redeemSingle` state
+ */
+const redeemSingleValidator: StateValidator = state => {
+  const { bAssetOutputs, mAssetData } = state;
+  const enabled = bAssetOutputs.filter(b => b.enabled)[0];
+
+  if (!enabled) {
+    return [false, Reasons.NoTokenSelected];
+  }
+
+  const overweightBassets = (mAssetData as NonNullable<MassetData>).bAssets
+    .filter(b => b.overweight)
+    .map(b => b.address);
+
+  if (
+    overweightBassets.length === 1 &&
+    overweightBassets[0] !== enabled.address
+  ) {
+    return [false, Reasons.MustRedeemOverweightBassets, overweightBassets];
+  }
+
+  return validate.redeemOutputValidator(state);
+};
+
+/**
+ * Validate `redeemMulti` state
+ * TODO: support redeemMulti validation
+ */
+const redeemMultiValidator: StateValidator = () => {
+  throw new Error('redeemMulti not supported');
+};
+
+const amountValidator: StateValidator = state => {
+  const {
+    mAssetData,
+    redemption: { amount },
+  } = state;
+
+  if (!mAssetData?.token.balance) {
+    return [false, Reasons.FetchingData];
+  }
+
+  if (!amount.exact) {
+    return [false, Reasons.AmountMustBeSet];
+  }
+
+  if (amount.exact.gt(mAssetData.token.balance)) {
+    return [false, Reasons.AmountExceedsBalance];
+  }
+
+  if (amount.exact.eq(0)) {
+    return [false, Reasons.AmountMustBeGreaterThanZero];
+  }
+
+  return [true];
+};
+
+/**
+ * Validate `redeemMasset` state
+ */
+const redeemMassetValidator: StateValidator = state => {
+  const {
+    mAssetData,
+    bAssetOutputs,
+    redemption: { amount },
+  } = state;
+
+  const enabled = bAssetOutputs.filter(b => b.enabled);
+
+  if (enabled.length === 0) {
+    return [false, Reasons.NoTokensSelected];
+  }
+
+  const bAssets = combineBassetsData(state);
+
+  const basketCollateralisationRatio = bigNumberify(
+    (mAssetData as NonNullable<MassetData>).basket.collateralisationRatio,
+  );
+
+  const collateralisationRatio = EXP_SCALE.lt(basketCollateralisationRatio)
+    ? EXP_SCALE
+    : basketCollateralisationRatio;
+
+  const collateralisedMassetQuantity = (amount.exact as NonNullable<BigNumber>)
+    .mul(collateralisationRatio)
+    .div(EXP_SCALE);
+
+  const ratioedBassetVaults = bAssets.map(
+    ({ vaultBalanceExact, data: { ratio } }) =>
+      applyRatioMassetToBasset(vaultBalanceExact, ratio),
+  );
+
+  const totalBassetVault = ratioedBassetVaults.reduce(
+    (_totalBassetVault, ratioedBassetVault) =>
+      _totalBassetVault.add(ratioedBassetVault),
+    new BigNumber(0),
+  );
+
+  if (totalBassetVault.eq(0)) {
+    return [false, Reasons.NothingInTheBasketToRedeem];
+  }
+
+  if (collateralisedMassetQuantity.gt(totalBassetVault)) {
+    return [false, Reasons.NotEnoughLiquidity];
+  }
+
+  return [true];
+};
+
+/**
+ * Validate the basket state for all redemption modes
+ */
+const basketValidator: StateValidator = ({ mAssetData, mode }) => {
+  if (!(mAssetData?.basket && mAssetData.token.balance)) {
+    return [false, Reasons.FetchingData];
+  }
+
+  if (mAssetData.bAssets.some(b => b.status === BassetStatus.Blacklisted)) {
+    return [false, Reasons.BasketContainsBlacklistedAsset];
+  }
+
+  if (
+    mode !== Mode.RedeemMasset &&
+    (mAssetData.basket.failed ||
+      mAssetData.bAssets.some(b => b.status !== BassetStatus.Normal) ||
+      mAssetData.bAssets.filter(b => b.overweight).length > 1)
+  ) {
+    return [false, Reasons.MustRedeemProportionally];
+  }
+
+  if (mAssetData.basket.undergoingRecol) {
+    return [false, Reasons.RedemptionPausedDuringRecol];
+  }
+
+  return [true];
+};
+
+const redemptionValidator: StateValidator = state => {
+  const amountValidation = validate.amountValidator(state);
+  if (!amountValidation[0]) return amountValidation;
+
+  if (state.mode === Mode.RedeemMasset) {
+    return validate.redeemMassetValidator(state);
+  }
+
+  if (state.mode === Mode.RedeemSingle) {
+    return validate.redeemSingleValidator(state);
+  }
+
+  return validate.redeemMultiValidator(state);
+};
+
+const applyValidation = (state: State): State => {
+  const [basketValid, basketError] = validate.basketValidator(state);
+  const [redeemValid, redeemError, errors = []] = validate.redemptionValidator(
+    state,
+  );
+
+  const error = state.touched ? basketError || redeemError : undefined;
+  const valid = !!(state.touched && basketValid && redeemValid);
+
   return {
     ...state,
+    bAssetOutputs: state.bAssetOutputs.map(bAsset => ({
+      ...bAsset,
+      error: error && errors.includes(bAsset.address) ? error : undefined,
+    })),
     error,
-    valid: touched && !error,
+    valid,
   };
+};
+
+export const validate = {
+  applyValidation,
+  amountValidator,
+  basketValidator,
+  redeemMassetValidator,
+  redeemMultiValidator,
+  redeemSingleValidator,
+  redeemOutputValidator,
+  redemptionValidator,
 };

--- a/src/components/pages/Redeem/validate.ts
+++ b/src/components/pages/Redeem/validate.ts
@@ -113,26 +113,6 @@ const redeemOutputValidator: StateValidator = state => {
     ];
   }
 
-  // const amountExceedingMassetBalance = enabled.filter(
-  //   ({
-  //     data: {
-  //       token: { balance },
-  //     },
-  //     output: {
-  //       amount: { exact },
-  //     },
-  //   }) =>
-  //     (exact as NonNullable<BigNumber>).gt(balance as NonNullable<BigNumber>),
-  // );
-
-  // if (amountExceedingMassetBalance.length > 0) {
-  //   return [
-  //     false,
-  //     Reasons.AmountExceedsBalance,
-  //     amountExceedingMassetBalance.map(b => b.data.address),
-  //   ];
-  // }
-
   const vaultBalancesExceeded = enabled.filter(
     ({
       vaultBalanceExact,

--- a/src/components/pages/Redeem/validate.ts
+++ b/src/components/pages/Redeem/validate.ts
@@ -2,13 +2,12 @@
 
 import { BigNumber, bigNumberify, parseUnits } from 'ethers/utils';
 import { BassetData, MassetData } from '../../../context/DataProvider/types';
-import { applyRatioMassetToBasset } from '../../../web3/ratio';
-import { EXP_SCALE, RATIO_SCALE } from '../../../web3/constants';
+import { applyRatioBassetToMasset } from '../../../web3/ratio';
+import { EXP_SCALE, PERCENT_SCALE } from '../../../web3/constants';
 import { BassetStatus } from '../Mint/types';
 import { BassetOutput, Mode, Reasons, State, StateValidator } from './types';
 
-// It's not possible to construct a BigNumber with `5e22`
-const WEIGHT_THRESHOLD = new BigNumber((5e20).toString()).mul(100);
+const WEIGHT_THRESHOLD = new BigNumber(50000).mul(EXP_SCALE);
 
 /**
  * Combine bAsset output state with data from the mAsset
@@ -38,7 +37,7 @@ const redeemOutputValidator: StateValidator = state => {
   const bAssets = combineBassetsData(state);
   const enabled = bAssets.filter(b => b.output.enabled);
 
-  const onePercentOfTotal = totalVault.mul(RATIO_SCALE).div(EXP_SCALE);
+  const onePercentOfTotal = totalVault.mul(PERCENT_SCALE).div(EXP_SCALE);
 
   const weightBreachThreshold = onePercentOfTotal.gt(WEIGHT_THRESHOLD)
     ? WEIGHT_THRESHOLD
@@ -50,7 +49,7 @@ const redeemOutputValidator: StateValidator = state => {
 
   const ratioedBassetVaults = bAssets.map(
     ({ data: { ratio }, vaultBalanceExact }) =>
-      applyRatioMassetToBasset(vaultBalanceExact, ratio),
+      applyRatioBassetToMasset(vaultBalanceExact, ratio),
   );
 
   const breachedBassets = bAssets.filter((_, index) => {
@@ -157,7 +156,7 @@ const redeemOutputValidator: StateValidator = state => {
       output: {
         amount: { exact },
       },
-    }) => (exact ? applyRatioMassetToBasset(exact, ratio) : new BigNumber(0)),
+    }) => (exact ? applyRatioBassetToMasset(exact, ratio) : new BigNumber(0)),
   );
 
   const newRatioedBassetVaults = ratioedBassetVaults.map((r, index) =>
@@ -283,7 +282,7 @@ const redeemMassetValidator: StateValidator = state => {
 
   const ratioedBassetVaults = bAssets.map(
     ({ vaultBalanceExact, data: { ratio } }) =>
-      applyRatioMassetToBasset(vaultBalanceExact, ratio),
+      applyRatioBassetToMasset(vaultBalanceExact, ratio),
   );
 
   const totalBassetVault = ratioedBassetVaults.reduce(

--- a/src/components/pages/Save/validate.ts
+++ b/src/components/pages/Save/validate.ts
@@ -26,7 +26,7 @@ const validate = ({
     return Reasons.TokenMustBeSelected;
   }
 
-  if (!(mUsdToken?.balance && exchangeRate)) {
+  if (!mUsdToken?.balance) {
     return Reasons.FetchingData;
   }
 
@@ -41,7 +41,7 @@ const validate = ({
   }
 
   if (transactionType === TransactionType.Withdraw) {
-    if (!savingsBalance?.creditsExact) {
+    if (!savingsBalance?.creditsExact || !exchangeRate) {
       return Reasons.FetchingData;
     }
 

--- a/src/components/pages/Swap/SwapConfirm.tsx
+++ b/src/components/pages/Swap/SwapConfirm.tsx
@@ -2,11 +2,13 @@ import React, { FC } from 'react';
 import { P } from '../../core/Typography';
 import { CountUp } from '../../core/CountUp';
 import { useSwapState } from './SwapProvider';
+import { formatExactAmount } from '../../../web3/amounts';
 
 export const SwapConfirm: FC<{}> = () => {
   const {
     values: { input, output, feeAmountSimple },
     valid,
+    mAssetData,
   } = useSwapState();
 
   return valid && input.amount.simple && output.amount.simple ? (
@@ -22,13 +24,14 @@ export const SwapConfirm: FC<{}> = () => {
         </span>
         {feeAmountSimple ? null : <span> (1:1)</span>}.
       </P>
-      {feeAmountSimple ? (
+      {feeAmountSimple && mAssetData?.feeRate ? (
         <>
           <P size={1}>
             This includes a swap fee of
             <span>
               {' '}
-              <CountUp end={parseFloat(feeAmountSimple)} decimals={4} /> mUSD
+              <CountUp end={parseFloat(feeAmountSimple)} decimals={4} /> mUSD (
+              {formatExactAmount(mAssetData?.feeRate, 16, '%')})
             </span>
             .
           </P>

--- a/src/components/wallet/HistoricTransactions.tsx
+++ b/src/components/wallet/HistoricTransactions.tsx
@@ -197,12 +197,6 @@ const getHistoricTransactionDescription = (
       );
     }
     case 'redeem': {
-      // const totalFee = logs.reduce(
-      //   (_totalFee, { values: { feeQuantity } }) =>
-      //     feeQuantity ? _totalFee.add(feeQuantity) : _totalFee,
-      //   new BigNumber(0),
-      // );
-
       const {
         values: { mAssetQuantity, bAssets },
       } = logs[logs.length - 1];

--- a/src/components/wallet/HistoricTransactions.tsx
+++ b/src/components/wallet/HistoricTransactions.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useMemo } from 'react';
 import styled from 'styled-components';
-import { BigNumber } from 'ethers/utils';
 import { useOrderedHistoricTransactions } from '../../context/TransactionsProvider';
 import { ContractNames, HistoricTransaction } from '../../types';
 import { EtherscanLink } from '../core/EtherscanLink';
@@ -198,14 +197,14 @@ const getHistoricTransactionDescription = (
       );
     }
     case 'redeem': {
-      const totalFee = logs.reduce(
-        (_totalFee, { values: { feeQuantity } }) =>
-          feeQuantity ? _totalFee.add(feeQuantity) : _totalFee,
-        new BigNumber(0),
-      );
+      // const totalFee = logs.reduce(
+      //   (_totalFee, { values: { feeQuantity } }) =>
+      //     feeQuantity ? _totalFee.add(feeQuantity) : _totalFee,
+      //   new BigNumber(0),
+      // );
 
       const {
-        values: { mAssetQuantity, bAssets, bAssetQuantities },
+        values: { mAssetQuantity, bAssets },
       } = logs[logs.length - 1];
 
       const bassetTokens = bAssets
@@ -219,25 +218,19 @@ const getHistoricTransactionDescription = (
       return (
         <>
           You <span>redeemed</span>{' '}
-          {humanizeList(
-            bAssets.map((address: string, index: number) =>
-              formatExactAmount(
-                bAssetQuantities[index],
-                bassetTokens[index].token.decimals,
-                bassetTokens[index].token.symbol,
-                true,
-              ),
-            ),
-          )}{' '}
-          for{' '}
           {formatExactAmount(
             mAssetQuantity,
             mUSD.token.decimals,
             mUSD.token.symbol,
             true,
-          )}{' '}
-          (fee paid:{' '}
-          {formatExactAmount(totalFee, mUSD.token.decimals, mUSD.token.symbol)})
+          )}
+          {' into '}
+          {humanizeList(
+            bAssets.map(
+              (address: string, index: number) =>
+                bassetTokens[index].token.symbol,
+            ),
+          )}
         </>
       );
     }

--- a/src/components/wallet/Transactions.tsx
+++ b/src/components/wallet/Transactions.tsx
@@ -215,16 +215,10 @@ const getPendingTxDescription = (
           {formatExactAmount(
             bassetQ,
             basset.token.decimals,
-            basset.token.symbol,
-            true,
-          )}{' '}
-          with{' '}
-          {formatExactAmount(
-            bassetQ,
-            mUSD.token.decimals,
             mUSD.token.symbol,
             true,
-          )}
+          )}{' '}
+          into {basset.token.symbol}
         </>
       );
     }

--- a/src/context/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider.tsx
@@ -261,12 +261,8 @@ const getTxPurpose = (
       const body = `${formatExactAmount(
         bassetQ,
         bAsset.token.decimals,
-        bAsset.token.symbol,
-      )} with ${formatExactAmount(
-        bassetQ,
-        bAsset.token.decimals,
         mUsd.token.symbol,
-      )}`;
+      )} into ${bAsset.token.symbol}`;
       return {
         present: `Redeeming ${body}`,
         past: `Redeemed ${body}`,

--- a/src/web3/amounts.ts
+++ b/src/web3/amounts.ts
@@ -27,7 +27,7 @@ export const formatSimpleAmount = (
  * @param commas Add comma separators to separate thousands
  */
 export const formatExactAmount = (
-  exactAmount?: BigNumber,
+  exactAmount?: BigNumber | string,
   decimals?: number,
   symbol?: string,
   commas = false,

--- a/src/web3/ratio.ts
+++ b/src/web3/ratio.ts
@@ -1,12 +1,18 @@
-import { BigNumber } from 'ethers/utils';
+import { BigNumber, bigNumberify, BigNumberish } from 'ethers/utils';
 import { RATIO_SCALE } from './constants';
 
 export const applyRatioMassetToBasset = (
-  input: BigNumber,
-  ratio: BigNumber,
-): BigNumber => input.mul(RATIO_SCALE).div(ratio);
+  input: BigNumberish,
+  ratio: BigNumberish,
+): BigNumber =>
+  bigNumberify(input)
+    .mul(RATIO_SCALE)
+    .div(ratio);
 
 export const applyRatioBassetToMasset = (
-  input: BigNumber,
-  ratio: BigNumber,
-): BigNumber => input.mul(ratio).div(RATIO_SCALE);
+  input: BigNumberish,
+  ratio: BigNumberish,
+): BigNumber =>
+  bigNumberify(input)
+    .mul(ratio)
+    .div(RATIO_SCALE);


### PR DESCRIPTION
Support single bAsset redemption

* Support either `redeem` (single bAsset) redemption or `redeemMasset` (all bAssets, proportional) for the redeem form
* Remove bAssets from pending transaction description for redemption
* Show swap fee (when applicable) when redeeming
* Validate `redeemMasset` more thoroughly
