### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ number doesn't increase when under a small threshold (i.e. near-zero)
 
 Bug fixes:
 
-* Fix setting the max amount for savings contract withdrawals
+* Fix setting the max amount for savings contract withdrawals and for redeeming
 * Fix the detection of breached bAssets; the one percent of the 
 total vault that forms the basis of the weight breach threshold 
 should be based on the total supply of the mAsset (i.e. total of 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Next
 
+
+Miscellaneous:
+
+* Round down simple numbers to the nearest decimal place
+* Adjust the behaviour of `useIncreasingNumber` such that the 
+number doesn't increase when under a small threshold (i.e. near-zero)
+* Make failed transactions more obvious (in the wallet view)
+* Fix line height for mUSD savings balance
+
+Bug fixes:
+
+* Fix setting the max amount for savings contract withdrawals
+* Fix the detection of breached bAssets; the one percent of the 
+total vault that forms the basis of the weight breach threshold 
+should be based on the total supply of the mAsset (i.e. total of 
+all vaults)
+* Remove mAsset from other token balances in wallet view
+
+
+## Version 1.1.0
+
+_Released 16.06.20 17.40 CEST_
+
 New features:
 
 * Adjust the mint/save/redeem forms such that a simulated state is produced based on the form inputs
@@ -26,7 +49,7 @@ Bug fixes:
 * Fix number input handling for increments
 
 
-## Version 1.0
+## Version 1.0.0
 
 _Released 27.05.20 18.38 CEST_
 

--- a/src/components/pages/Mint/BassetInput.tsx
+++ b/src/components/pages/Mint/BassetInput.tsx
@@ -187,7 +187,10 @@ export const BassetInput: FC<Props> = ({ address }) => {
             </Button>
           ) : null}
         </InputContainer>
-        <CountUp container={BalanceContainer} end={balance?.simple || 0} />
+        <CountUp
+          container={BalanceContainer}
+          end={balance?.simpleRounded || 0}
+        />
       </Grid>
       {error || overweight ? (
         <Error>{error || 'Asset overweight'}</Error>

--- a/src/components/pages/Mint/index.tsx
+++ b/src/components/pages/Mint/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../forms/TransactionForm/FormProvider';
 import { TransactionForm } from '../../forms/TransactionForm';
 import { Interfaces } from '../../../types';
-import { MintProvider, useMintSimulation, useMintState } from "./MintProvider";
+import { MintProvider, useMintState } from "./MintProvider";
 import { MintInput } from './MintInput';
 import { MusdStats } from '../../stats/MusdStats';
 
@@ -70,16 +70,11 @@ const MintForm: FC<{}> = () => {
   );
 };
 
-const MintStats: FC<{}> = () => {
-  const simulation = useMintSimulation();
-  return <MusdStats simulation={simulation} />
-}
-
 export const Mint: FC<{}> = () => (
   <MintProvider>
     <FormProvider formId="mint">
       <MintForm />
-      <MintStats />
+      <MusdStats />
     </FormProvider>
   </MintProvider>
 );

--- a/src/components/pages/Redeem/BassetOutput.tsx
+++ b/src/components/pages/Redeem/BassetOutput.tsx
@@ -113,12 +113,12 @@ export const BassetOutput: FC<Props> = ({ address }) => {
         </HeaderRow>
         <Row>
           <Label>Your Balance</Label>
-          <CountUp end={balance?.simple || 0} />
+          <CountUp end={balance?.simpleRounded || 0} />
         </Row>
         <Row>
           <Label>Amount</Label>
           <CountUp
-            highlight={(amount?.simple || 0) > 0}
+            highlight={(amount?.simpleRounded || 0) > 0}
             highlightColor={Color.green}
             duration={0.4}
             end={amount?.simple || 0}

--- a/src/components/pages/Redeem/reducer.ts
+++ b/src/components/pages/Redeem/reducer.ts
@@ -59,6 +59,7 @@ const reduce: Reducer<State, Action> = (state, action) => {
         ...state,
         amountInMasset: maxAmount,
         formValue: maxAmount.format(2, false),
+        touched: true,
       };
     }
 

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -27,6 +27,7 @@ const CreditBalance = styled.div`
   span {
     font-weight: bold;
     font-size: 6vw;
+    line-height: 1em;
   }
 
   @media (min-width: ${({ theme }) => theme.viewportWidth.s}) {

--- a/src/components/pages/Save/SaveProvider.tsx
+++ b/src/components/pages/Save/SaveProvider.tsx
@@ -32,10 +32,10 @@ export const SaveProvider: FC<{}> = ({ children }) => {
   }, [dataState]);
 
   const setAmount = useCallback<Dispatch['setAmount']>(
-    (formValue, isCreditAmount = false) => {
+    (formValue) => {
       dispatch({
         type: Actions.SetAmount,
-        payload: { formValue, isCreditAmount },
+        payload: { formValue },
       });
     },
     [dispatch],

--- a/src/components/pages/Save/reducer.ts
+++ b/src/components/pages/Save/reducer.ts
@@ -61,11 +61,6 @@ const reduce: Reducer<State, Action> = (state, action) => {
 
       const maybeAmount = BigDecimal.maybeParse(formValue, decimals);
 
-      const amount =
-        isWithdraw && exchangeRate
-          ? maybeAmount?.mulTruncate(exchangeRate.exact)
-          : maybeAmount;
-
       const amountInCredits =
         isWithdraw && maybeAmount && exchangeRate
           ? maybeAmount.divPrecisely(exchangeRate)
@@ -74,7 +69,7 @@ const reduce: Reducer<State, Action> = (state, action) => {
       return {
         ...state,
         amountInCredits,
-        amount,
+        amount: maybeAmount,
         formValue,
         touched: !!formValue,
       };

--- a/src/components/pages/Save/types.ts
+++ b/src/components/pages/Save/types.ts
@@ -46,7 +46,6 @@ export type Action =
       type: Actions.SetAmount;
       payload: {
         formValue: string | null;
-        isCreditAmount: boolean;
       };
     }
   | { type: Actions.SetMaxAmount }

--- a/src/components/wallet/Balances.tsx
+++ b/src/components/wallet/Balances.tsx
@@ -55,10 +55,9 @@ export const Balances: FC<{}> = () => {
 
   const { mAsset, savingsContract, bAssets } = useDataState() || {};
 
-  const otherTokens = useMemo(
-    () => (mAsset && bAssets ? [mAsset, ...Object.values(bAssets)] : []),
-    [mAsset, bAssets],
-  );
+  const otherTokens = useMemo(() => (bAssets ? Object.values(bAssets) : []), [
+    bAssets,
+  ]);
 
   const themeContext = useContext(ThemeContext);
 

--- a/src/components/wallet/Transactions.tsx
+++ b/src/components/wallet/Transactions.tsx
@@ -237,6 +237,7 @@ const PendingTx: FC<{
     <PendingTxContainer inverted={inverted}>
       <TxStatusIndicator tx={tx} />
       <EtherscanLink data={tx.hash} type="transaction">
+        {tx.status === 0 ? 'Error: ' : ''}
         {description}
       </EtherscanLink>
     </PendingTxContainer>

--- a/src/context/DataProvider/recalculateState.ts
+++ b/src/context/DataProvider/recalculateState.ts
@@ -27,7 +27,7 @@ const calculateBasset = (
     : new BigDecimal(0, mAsset.decimals)
   ).divPrecisely(mAsset.totalSupply);
 
-  const onePercentOfTotalVault = bAsset.totalVault.exact
+  const onePercentOfTotalVault = mAsset.totalSupply.exact
     .mul(PERCENT_SCALE)
     .div(SCALE);
 

--- a/src/web3/BigDecimal.ts
+++ b/src/web3/BigDecimal.ts
@@ -62,6 +62,15 @@ export class BigDecimal {
   }
 
   /**
+   * Returns a "simple number" version of the value which has been rounded down
+   * to 2 decimal places.
+   * @return simple number value, rounded down to 2 decimals
+   */
+  get simpleRounded(): number {
+    return parseFloat(this.simple.toFixed(3).slice(0, -1));
+  }
+
+  /**
    * Returns a formatted string version of the value, without commas.
    * @return string value
    */
@@ -81,13 +90,15 @@ export class BigDecimal {
 
   /**
    * Returns a formatted value to the given decimal places, with optional commas
+   * and round it down
    * @param decimalPlaces
    * @param commas
    * @return formatted string value
    */
   format(decimalPlaces = 2, commas = true): string {
-    const fixed = this.simple.toFixed(decimalPlaces);
-    return commas ? commify(fixed) : fixed;
+    const fixed = this.simple.toFixed(decimalPlaces + 1);
+    const rounded = parseFloat(fixed.slice(0, -1)).toFixed(decimalPlaces);
+    return commas ? commify(rounded) : rounded;
   }
 
   /**

--- a/src/web3/hooks.ts
+++ b/src/web3/hooks.ts
@@ -98,7 +98,7 @@ export const useIncreasingNumber = (
   }, [value, setValueInc]);
 
   useInterval(() => {
-    if (valueInc) setValueInc(valueInc + increment);
+    if (valueInc && value && value > 0.001) setValueInc(valueInc + increment);
   }, interval);
 
   return valueInc;


### PR DESCRIPTION
Miscellaneous:

* Round down simple numbers to the nearest decimal place
* Adjust the behaviour of `useIncreasingNumber` such that the number doesn't increase when under a small threshold (i.e. near-zero)
* Make failed transactions more obvious (in the wallet view)
* Fix line height for mUSD savings balance
* Load token balances before blocks come through

Bug fixes:

* Fix setting the max amount for savings contract withdrawals and redeeming
* Fix the detection of breached bAssets; the one percent of the total vault that forms the basis of the weight breach threshold should be based on the total supply of the mAsset (i.e. total of all vaults)
* Remove mAsset from other token balances in wallet view

Fixes #90 