### PR TITLE
Fix savings withdrawal decimal issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Next
 
+## Version 1.1.2
+
+_Released 19.06.20 17.30 CEST_
+
+Fixing a regression introduced in the 1.1.0 refactor
+
+Bug fixes:
+
+- Fix withdrawing whole numbers from SAVE by adding an extra credit (previously, when redeeming
+  100 mUSD, it would actually redeem 99.9999999999999)
 
 ## Version 1.1.1
 
@@ -9,21 +19,20 @@ _Released 17.06.20 11.34 CEST_
 
 Miscellaneous:
 
-* Round down simple numbers to the nearest decimal place
-* Adjust the behaviour of `useIncreasingNumber` such that the 
-number doesn't increase when under a small threshold (i.e. near-zero)
-* Make failed transactions more obvious (in the wallet view)
-* Fix line height for mUSD savings balance
+- Round down simple numbers to the nearest decimal place
+- Adjust the behaviour of `useIncreasingNumber` such that the
+  number doesn't increase when under a small threshold (i.e. near-zero)
+- Make failed transactions more obvious (in the wallet view)
+- Fix line height for mUSD savings balance
 
 Bug fixes:
 
-* Fix setting the max amount for savings contract withdrawals and for redeeming
-* Fix the detection of breached bAssets; the one percent of the 
-total vault that forms the basis of the weight breach threshold 
-should be based on the total supply of the mAsset (i.e. total of 
-all vaults)
-* Remove mAsset from other token balances in wallet view
-
+- Fix setting the max amount for savings contract withdrawals and for redeeming
+- Fix the detection of breached bAssets; the one percent of the
+  total vault that forms the basis of the weight breach threshold
+  should be based on the total supply of the mAsset (i.e. total of
+  all vaults)
+- Remove mAsset from other token balances in wallet view
 
 ## Version 1.1.0
 
@@ -31,30 +40,29 @@ _Released 16.06.20 17.40 CEST_
 
 New features:
 
-* Adjust the mint/save/redeem forms such that a simulated state is produced based on the form inputs
-* Animate the basket stats graphic
-* Automatically reconnect the wallet once on startup (if possible)
+- Adjust the mint/save/redeem forms such that a simulated state is produced based on the form inputs
+- Animate the basket stats graphic
+- Automatically reconnect the wallet once on startup (if possible)
 
-Refactors: 
+Refactors:
 
-* Create a wrapper class for `BigNumber` (`bn.js`) to support operations on big decimal numbers, mirroring functionality from `StableMath`
-* Use `BigDecimal` throughout the app (except some parts of the swap form, which haven't been refactored)
-* Use pipelines to reduce state actions, simulate and validate for form state
-* Move 'set max' into reducers
-* Consolidate all mAsset/bAssets calculations in one place, so that the state can be recalculated when the underlying data changes; this also facilitates data simulations.
+- Create a wrapper class for `BigNumber` (`bn.js`) to support operations on big decimal numbers, mirroring functionality from `StableMath`
+- Use `BigDecimal` throughout the app (except some parts of the swap form, which haven't been refactored)
+- Use pipelines to reduce state actions, simulate and validate for form state
+- Move 'set max' into reducers
+- Consolidate all mAsset/bAssets calculations in one place, so that the state can be recalculated when the underlying data changes; this also facilitates data simulations.
 
 Miscellaneous:
 
-* Reset form errors when amounts are unset
-* Adjust form error style
+- Reset form errors when amounts are unset
+- Adjust form error style
 
 Bug fixes:
 
-* Fix number input handling for increments
-
+- Fix number input handling for increments
 
 ## Version 1.0.0
 
 _Released 27.05.20 18.38 CEST_
 
-* Initial release
+- Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mStable-app",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "mStable App",
   "author": "Stability Labs Pty. Ltd. <hello@stabilitylabs.co>",

--- a/src/components/pages/Save/SaveProvider.tsx
+++ b/src/components/pages/Save/SaveProvider.tsx
@@ -32,7 +32,7 @@ export const SaveProvider: FC<{}> = ({ children }) => {
   }, [dataState]);
 
   const setAmount = useCallback<Dispatch['setAmount']>(
-    (formValue) => {
+    formValue => {
       dispatch({
         type: Actions.SetAmount,
         payload: { formValue },

--- a/src/components/pages/Save/reducer.ts
+++ b/src/components/pages/Save/reducer.ts
@@ -63,7 +63,7 @@ const reduce: Reducer<State, Action> = (state, action) => {
 
       const amountInCredits =
         isWithdraw && maybeAmount && exchangeRate
-          ? maybeAmount.divPrecisely(exchangeRate)
+          ? maybeAmount.divPrecisely(exchangeRate).add(new BigDecimal(1, 0))
           : undefined;
 
       return {


### PR DESCRIPTION
From CHANGELOG:

`Fix withdrawing whole numbers from SAVE by adding an extra credit (previously, when redeeming 100 mUSD, it would actually redeem 99.9999999999999)`