### PR TITLE
Adjust redemption validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Next
 
+Bug fixes:
+
+- Ensure that overweight bAssets can be redeemed single, so long as doing so does not push 
+other bAssets past their weights
+- Clarify the redeem validation; output validation checks the simulated state, after 
+the change
+- Ensure that the overweight bAssets check overrides the breached bAssets check (i.e. so that 
+`redeemMasset` is only enforced for breached bAssets when there are no overweight bAssets)
+- Check that vault balances are not exceeded for a redemption against the current state of 
+the basket, and with the bAsset units
+- Ensure the swap fee is updated when selecting a different token in the swap form
+- Fix rounding of formatted BigDecimals
+
+Miscellaneous:
+
+- Always show token symbols with balances under inputs
+- Show the 'low fee' item when there is a fee
+- Show 'asset overweight' on redeem bAsset outputs when the bAsset is overweight
+- Do not use simulation for redeem stats
+
 ## Version 1.1.2
 
 _Released 19.06.20 17.30 CEST_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mStable-app",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "description": "mStable App",
   "author": "Stability Labs Pty. Ltd. <hello@stabilitylabs.co>",

--- a/src/components/pages/Redeem/BassetOutput.tsx
+++ b/src/components/pages/Redeem/BassetOutput.tsx
@@ -99,7 +99,15 @@ export const BassetOutput: FC<Props> = ({ address }) => {
   const { error, enabled, amount } = useRedeemBassetOutput(address) || {};
   const mode = useRedeemMode();
   const toggle = useToggleBassetEnabled();
-  const toggleDisabled = mode === Mode.RedeemSingle && overweight;
+
+  const { mAsset: { overweightBassets } = { overweightBassets: [] } } =
+    useDataState() || {};
+
+  const toggleDisabled = !!(
+    mode === Mode.RedeemSingle &&
+    overweightBassets.length > 0 &&
+    overweightBassets.find(b => b !== address)
+  );
 
   return (
     <div>

--- a/src/components/pages/Redeem/BassetOutput.tsx
+++ b/src/components/pages/Redeem/BassetOutput.tsx
@@ -6,6 +6,7 @@ import { Color } from '../../../theme';
 import { CountUp as CountUpBase } from '../../core/CountUp';
 import { Token } from '../../core/Token';
 import { ToggleInput } from '../../forms/ToggleInput';
+import { useDataState } from '../../../context/DataProvider/DataProvider';
 import {
   useRedeemBassetData,
   useRedeemBassetOutput,
@@ -126,10 +127,10 @@ export const BassetOutput: FC<Props> = ({ address }) => {
           />
         </Row>
       </Rows>
-      {error ? (
+      {error || overweight ? (
         <ErrorRow>
-          <Label>Unable to redeem</Label>
-          <Value>{error}</Value>
+          {error ? <Label>Unable to redeem</Label> : null}
+          <Value>{error || 'Asset overweight'}</Value>
         </ErrorRow>
       ) : null}
     </div>

--- a/src/components/pages/Redeem/RedeemInput.tsx
+++ b/src/components/pages/Redeem/RedeemInput.tsx
@@ -49,7 +49,7 @@ export const RedeemInput: FC<{}> = () => {
   const items = useMemo(() => {
     const balance = {
       label: 'Balance',
-      value: mAsset?.balance.format(),
+      value: mAsset?.balance.format(2, true, 'mUSD'),
     };
 
     return feeAmount && valid

--- a/src/components/pages/Redeem/index.tsx
+++ b/src/components/pages/Redeem/index.tsx
@@ -11,11 +11,7 @@ import { TransactionForm } from '../../forms/TransactionForm';
 import { MusdStats } from '../../stats/MusdStats';
 import { RedeemInput } from './RedeemInput';
 import { RedeemConfirm } from './RedeemConfirm';
-import {
-  RedeemProvider,
-  useRedeemSimulation,
-  useRedeemState,
-} from './RedeemProvider';
+import { RedeemProvider, useRedeemState } from './RedeemProvider';
 import { Mode } from './types';
 
 const RedeemForm: FC<{}> = () => {
@@ -68,16 +64,11 @@ const RedeemForm: FC<{}> = () => {
   );
 };
 
-const RedeemStats: FC<{}> = () => {
-  const simulation = useRedeemSimulation(true);
-  return <MusdStats simulation={simulation} />;
-};
-
 export const Redeem: FC<{}> = () => (
   <RedeemProvider>
     <FormProvider formId="redeem">
       <RedeemForm />
-      <RedeemStats />
+      <MusdStats />
     </FormProvider>
   </RedeemProvider>
 );

--- a/src/components/pages/Redeem/reducer.ts
+++ b/src/components/pages/Redeem/reducer.ts
@@ -187,10 +187,10 @@ const updateBassetAmountsRedeemMasset = (
 const updateBassetAmountsRedeemSingle = (
   state: State & { dataState: DataState; amountInMasset: BigDecimal },
 ): State['bAssets'] => {
-  const { amountInMassetPlusFee, amountInMasset, feeAmount } = state;
+  const { amountInMasset, feeAmount } = state;
   const [enabledBasset] = Object.values(state.bAssets).filter(b => b.enabled);
 
-  if (!(enabledBasset && amountInMassetPlusFee && amountInMasset)) {
+  if (!(enabledBasset && amountInMasset)) {
     return state.bAssets;
   }
 

--- a/src/components/pages/Save/SaveInput.tsx
+++ b/src/components/pages/Save/SaveInput.tsx
@@ -47,7 +47,7 @@ export const SaveInput: FC<{}> = () => {
         ? [
             {
               label: 'Balance',
-              value: mAsset?.balance.format(),
+              value: mAsset?.balance.format(2, true, 'mUSD'),
             },
           ]
         : [],

--- a/src/components/pages/Swap/SwapInput.tsx
+++ b/src/components/pages/Swap/SwapInput.tsx
@@ -26,6 +26,7 @@ export const SwapInput: FC<{}> = () => {
     values: {
       input,
       output,
+      feeAmountSimple,
       input: { token: { address: inputAddress } = { address: null } },
       output: { token: { address: outputAddress } = { address: null } },
     },
@@ -79,7 +80,7 @@ export const SwapInput: FC<{}> = () => {
           true,
         ),
       },
-      ...(feeRate
+      ...(feeRate && feeAmountSimple
         ? [
             {
               label: 'Low fee 🎉',
@@ -96,7 +97,7 @@ export const SwapInput: FC<{}> = () => {
           ]
         : []),
     ],
-    [outputToken, feeRate],
+    [outputToken, feeRate, feeAmountSimple],
   );
 
   /**

--- a/src/components/pages/Swap/reducer.ts
+++ b/src/components/pages/Swap/reducer.ts
@@ -196,7 +196,7 @@ const calculateSwapValues = (
   };
 };
 
-export const reducer: Reducer<State, Action> = (state, action) => {
+const reduce: Reducer<State, Action> = (state, action) => {
   switch (action.type) {
     case Actions.SetToken:
       return applyValidation({
@@ -218,3 +218,9 @@ export const reducer: Reducer<State, Action> = (state, action) => {
       throw new Error('Unhandled action type');
   }
 };
+
+// XXX Each reducer action is re-run because `applyValidation` sets
+// `applySwapFee`, which is in turn checked by `calculateSwapValues`.
+// TODO later: refactor to use an explicit pipeline
+export const reducer: Reducer<State, Action> = (state, action) =>
+  reduce(reduce(state, action), action);

--- a/src/web3/BigDecimal.ts
+++ b/src/web3/BigDecimal.ts
@@ -97,8 +97,10 @@ export class BigDecimal {
    * @return formatted string value
    */
   format(decimalPlaces = 2, commas = true, suffix?: string): string {
-    const fixed = this.simple.toFixed(decimalPlaces + 1);
-    const rounded = parseFloat(fixed.slice(0, -1)).toFixed(decimalPlaces);
+    const [left, right = '00'] = this.simple.toString().split('.');
+    const truncatedRight =
+      right.length > decimalPlaces ? right.slice(0, decimalPlaces) : right;
+    const rounded = `${left}.${truncatedRight}`;
     const formatted = commas ? commify(rounded) : rounded;
     return `${formatted}${suffix ? ` ${suffix}` : ''}`;
   }

--- a/src/web3/BigDecimal.ts
+++ b/src/web3/BigDecimal.ts
@@ -90,15 +90,17 @@ export class BigDecimal {
 
   /**
    * Returns a formatted value to the given decimal places, with optional commas
-   * and round it down
+   * and optional suffix, and round it down
    * @param decimalPlaces
    * @param commas
+   * @param suffix
    * @return formatted string value
    */
-  format(decimalPlaces = 2, commas = true): string {
+  format(decimalPlaces = 2, commas = true, suffix?: string): string {
     const fixed = this.simple.toFixed(decimalPlaces + 1);
     const rounded = parseFloat(fixed.slice(0, -1)).toFixed(decimalPlaces);
-    return commas ? commify(rounded) : rounded;
+    const formatted = commas ? commify(rounded) : rounded;
+    return `${formatted}${suffix ? ` ${suffix}` : ''}`;
   }
 
   /**


### PR DESCRIPTION
Bug fixes:

- Ensure that overweight bAssets can be redeemed single, so long as doing so does not push 
other bAssets past their weights
- Clarify the redeem validation; output validation checks the simulated state, after 
the change
- Ensure that the overweight bAssets check overrides the breached bAssets check (i.e. so that 
`redeemMasset` is only enforced for breached bAssets when there are no overweight bAssets)
- Check that vault balances are not exceeded for a redemption against the current state of 
the basket, and with the bAsset units
- Ensure the swap fee is updated when selecting a different token in the swap form
- Fix rounding of formatted BigDecimals

Miscellaneous:

- Always show token symbols with balances under inputs
- Show the 'low fee' item when there is a fee
- Show 'asset overweight' on redeem bAsset outputs when the bAsset is overweight
- Do not use simulation for redeem stats
