### PR TITLE
Prevent enabling overweight bAssets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+Bug fixes:
+
+- Ensure that clicking on the input of an overweight (i.e. disabled) bAsset when minting
+does not enable the bAsset
+
 ## Version 1.1.3
 
 _Released 22.06.20 12.48 CEST_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mStable-app",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "description": "mStable App",
   "author": "Stability Labs Pty. Ltd. <hello@stabilitylabs.co>",

--- a/src/components/pages/Mint/BassetInput.tsx
+++ b/src/components/pages/Mint/BassetInput.tsx
@@ -151,10 +151,10 @@ export const BassetInput: FC<Props> = ({ address }) => {
   );
 
   const handleClickInput = useCallback(() => {
-    if (!enabled) {
+    if (!enabled && !overweight) {
       toggleBassetEnabled(address);
     }
-  }, [enabled, address, toggleBassetEnabled]);
+  }, [enabled, address, toggleBassetEnabled, overweight]);
 
   return (
     <Container overweight={overweight} valid={!error}>


### PR DESCRIPTION
- Ensure that clicking on the input of an overweight (i.e. disabled) bAsset when minting does not enable the bAsset