### PR TITLE
Fix finalize dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Bug fixes:
 
 - Ensure that clicking on the input of an overweight (i.e. disabled) bAsset when minting
 does not enable the bAsset
+- Add `purpose` to `finalize` callback for transactions such that the callback has the 
+correct dependencies
 
 ## Version 1.1.3
 

--- a/src/context/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider.tsx
@@ -72,8 +72,9 @@ interface Dispatch {
    * Mark a current transaction as finalized with a transaction receipt.
    * @param hash
    * @param receipt
+   * @param purpose
    */
-  finalize(hash: string, receipt: TransactionReceipt): void;
+  finalize(hash: string, receipt: TransactionReceipt, purpose: Purpose): void;
 
   /**
    * Reset the state completely.
@@ -366,11 +367,9 @@ export const TransactionsProvider: FC<{}> = ({ children }) => {
   );
 
   const finalize = useCallback<Dispatch['finalize']>(
-    (hash, receipt) => {
+    (hash, receipt, purpose) => {
       const status = getTransactionStatus(receipt);
       const link = getEtherscanLinkForHash(hash);
-
-      const { purpose } = state.current[hash];
 
       if (status === TransactionStatus.Success) {
         addSuccessNotification('Transaction confirmed', purpose.past, link);
@@ -380,7 +379,7 @@ export const TransactionsProvider: FC<{}> = ({ children }) => {
 
       dispatch({ type: Actions.Finalize, payload: { hash, receipt } });
     },
-    [dispatch, addSuccessNotification, addErrorNotification, state],
+    [dispatch, addSuccessNotification, addErrorNotification],
   );
 
   const reset = useCallback(() => {

--- a/src/updaters/transactionsUpdater.ts
+++ b/src/updaters/transactionsUpdater.ts
@@ -48,7 +48,7 @@ export const TransactionsUpdater = (): null => {
                   if (!receipt) {
                     check(hash, blockNumber);
                   } else {
-                    finalize(hash, receipt);
+                    finalize(hash, receipt, current[hash].purpose);
                   }
                 }
               })


### PR DESCRIPTION
- Add `purpose` to `finalize` callback for transactions such that the callback has the correct dependencies