### PR TITLE
Remove concept of breached bAssets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Next
 
+New Features
+
+- Removes concept of 'breached' bAssets. Basket assets within 1% of their max weighting can now
+  be redeemed, with the 'Swap fee' applied
+
 Bug fixes:
 
 - Ensure that clicking on the input of an overweight (i.e. disabled) bAsset when minting
-does not enable the bAsset
+  does not enable the bAsset
 
 ## Version 1.1.3
 
@@ -13,14 +18,14 @@ _Released 22.06.20 12.48 CEST_
 
 Bug fixes:
 
-- Ensure that overweight bAssets can be redeemed single, so long as doing so does not push 
-other bAssets past their weights
-- Clarify the redeem validation; output validation checks the simulated state, after 
-the change
-- Ensure that the overweight bAssets check overrides the breached bAssets check (i.e. so that 
-`redeemMasset` is only enforced for breached bAssets when there are no overweight bAssets)
-- Check that vault balances are not exceeded for a redemption against the current state of 
-the basket, and with the bAsset units
+- Ensure that overweight bAssets can be redeemed single, so long as doing so does not push
+  other bAssets past their weights
+- Clarify the redeem validation; output validation checks the simulated state, after
+  the change
+- Ensure that the overweight bAssets check overrides the breached bAssets check (i.e. so that
+  `redeemMasset` is only enforced for breached bAssets when there are no overweight bAssets)
+- Check that vault balances are not exceeded for a redemption against the current state of
+  the basket, and with the bAsset units
 - Ensure the swap fee is updated when selecting a different token in the swap form
 - Fix rounding of formatted BigDecimals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug fixes:
 
 - Ensure that clicking on the input of an overweight (i.e. disabled) bAsset when minting
   does not enable the bAsset
+- Shows `amountMinusSwapFee` in the Redeem BassetOutput instead of `amount`
 
 ## Version 1.1.3
 

--- a/src/components/pages/Redeem/BassetOutput.tsx
+++ b/src/components/pages/Redeem/BassetOutput.tsx
@@ -96,7 +96,9 @@ const Rows = styled.div<{
 
 export const BassetOutput: FC<Props> = ({ address }) => {
   const { overweight, balance, symbol } = useRedeemBassetData(address) || {};
-  const { error, enabled, amount } = useRedeemBassetOutput(address) || {};
+  const { error, enabled, amountMinusFee } =
+    useRedeemBassetOutput(address) || {};
+
   const mode = useRedeemMode();
   const toggle = useToggleBassetEnabled();
 
@@ -127,10 +129,10 @@ export const BassetOutput: FC<Props> = ({ address }) => {
         <Row>
           <Label>Amount</Label>
           <CountUp
-            highlight={(amount?.simpleRounded || 0) > 0}
+            highlight={(amountMinusFee?.simpleRounded || 0) > 0}
             highlightColor={Color.green}
             duration={0.4}
-            end={amount?.simple || 0}
+            end={amountMinusFee?.simpleRounded || 0}
             prefix="+ "
           />
         </Row>

--- a/src/components/pages/Redeem/validate.ts
+++ b/src/components/pages/Redeem/validate.ts
@@ -60,15 +60,6 @@ const redeemSingleValidator: StateValidator = state => {
     ];
   }
 
-  const { breachedBassets: currentBreachedBassets } = dataState.mAsset;
-
-  if (
-    currentBreachedBassets.length > 0 &&
-    currentOverweightBassets.length === 0
-  ) {
-    return [false, Reasons.MustRedeemWithAllBassets, currentBreachedBassets];
-  }
-
   const amountsRequired = enabledBassets.filter(({ amount }) => !amount);
 
   if (amountsRequired.length > 0) {

--- a/src/context/DataProvider/recalculateState.ts
+++ b/src/context/DataProvider/recalculateState.ts
@@ -1,7 +1,4 @@
-import { BigNumber } from 'ethers/utils';
-
 import { BigDecimal } from '../../web3/BigDecimal';
-import { PERCENT_SCALE, SCALE, WEIGHT_THRESHOLD } from '../../web3/constants';
 import { BassetState, BassetStatus, DataState, MassetState } from './types';
 
 const calculateBasset = (
@@ -27,25 +24,6 @@ const calculateBasset = (
     : new BigDecimal(0, mAsset.decimals)
   ).divPrecisely(mAsset.totalSupply);
 
-  const onePercentOfTotalVault = mAsset.totalSupply.exact
-    .mul(PERCENT_SCALE)
-    .div(SCALE);
-
-  const weightBreachThreshold = new BigDecimal(
-    onePercentOfTotalVault.gt(WEIGHT_THRESHOLD)
-      ? WEIGHT_THRESHOLD
-      : onePercentOfTotalVault,
-    mAsset.decimals,
-  );
-
-  const lowerBound = weightBreachThreshold.exact.gt(maxWeightInMasset.exact)
-    ? new BigNumber(0)
-    : maxWeightInMasset.exact.sub(weightBreachThreshold.exact);
-
-  const weightBreached =
-    totalVaultInMasset.exact.gt(lowerBound) &&
-    totalVaultInMasset.exact.lte(maxWeightInMasset.exact);
-
   return {
     ...bAsset,
     balanceInMasset,
@@ -53,8 +31,6 @@ const calculateBasset = (
     maxWeightInMasset,
     overweight,
     totalVaultInMasset,
-    weightBreachThreshold,
-    weightBreached,
   };
 };
 
@@ -102,10 +78,6 @@ export const recalculateState = (dataState: DataState): DataState => {
     .filter(({ overweight }) => overweight)
     .map(b => b.address);
 
-  const breachedBassets = bAssetsArr
-    .filter(({ weightBreached }) => weightBreached)
-    .map(b => b.address);
-
   const blacklistedBassets = bAssetsArr
     .filter(({ status }) => status === BassetStatus.Blacklisted)
     .map(b => b.address);
@@ -119,7 +91,6 @@ export const recalculateState = (dataState: DataState): DataState => {
     mAsset: {
       ...dataState.mAsset,
       allBassetsNormal,
-      breachedBassets,
       blacklistedBassets,
       overweightBassets,
     },

--- a/src/context/DataProvider/transformRawData.ts
+++ b/src/context/DataProvider/transformRawData.ts
@@ -26,7 +26,6 @@ const getMassetState = ({
 
   // Initial values
   allBassetsNormal: false,
-  breachedBassets: [],
   blacklistedBassets: [],
   overweightBassets: [],
 });
@@ -40,8 +39,8 @@ const getSavingsContractState = ({
 }: RawData): DataState['savingsContract'] => ({
   address: savingsContractData.id,
   automationEnabled: savingsContractData.automationEnabled,
-  creditBalances: (creditBalances || []).map(
-    ({ amount }) => BigDecimal.parse(amount, mAsset.token.decimals),
+  creditBalances: (creditBalances || []).map(({ amount }) =>
+    BigDecimal.parse(amount, mAsset.token.decimals),
   ),
   latestExchangeRate: latestExchangeRate
     ? {
@@ -117,8 +116,6 @@ const getBassetsState = (
         maxWeightInMasset: new BigDecimal(0, mAsset.decimals),
         overweight: false,
         totalVaultInMasset: new BigDecimal(0, mAsset.decimals),
-        weightBreachThreshold: new BigDecimal(0, mAsset.decimals),
-        weightBreached: false,
       };
 
       return {

--- a/src/context/DataProvider/types.ts
+++ b/src/context/DataProvider/types.ts
@@ -59,8 +59,6 @@ export interface BassetState {
   totalSupply: BigDecimal;
   totalVault: BigDecimal;
   totalVaultInMasset: BigDecimal;
-  weightBreachThreshold: BigDecimal;
-  weightBreached: boolean;
 }
 
 export interface MassetState {
@@ -71,7 +69,6 @@ export interface MassetState {
   decimals: number;
   failed: boolean;
   feeRate: BigNumber;
-  breachedBassets: string[];
   blacklistedBassets: string[];
   overweightBassets: string[];
   symbol: string;

--- a/src/web3/constants.ts
+++ b/src/web3/constants.ts
@@ -57,5 +57,3 @@ export const CONNECTORS: Connector[] = [
 ];
 
 export const DAPP_VERSION = process.env.REACT_APP_VERSION;
-
-export const WEIGHT_THRESHOLD = new BigNumber(50000).mul(EXP_SCALE);


### PR DESCRIPTION

New features:

 - Removes concept of 'breached' bAssets. Basket assets within 1% of their max weighting can now be redeemed, with the 'Swap fee' applied