### PR TITLE
Fix initial allowance fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bug fixes:
 
 - Ensure that clicking on the input of an overweight (i.e. disabled) bAsset when minting
 does not enable the bAsset
+- Ensure that token balances and allowances are fetched as soon as they are available
 
 ## Version 1.1.3
 

--- a/src/updaters/tokenBalancesUpdater.ts
+++ b/src/updaters/tokenBalancesUpdater.ts
@@ -140,7 +140,7 @@ export const TokenBalancesUpdater = (): null => {
   // Update subscribed tokens on each block, and also if the account or number
   // of tokens changes
   useAsyncMutex(
-    `${account}-${blockNumber}-${Object.keys(contracts).length}`,
+    `${account}-${blockNumber}-${mUSDAddress}-${Object.keys(contracts).length}`,
     updateCallback,
   );
 


### PR DESCRIPTION
* Add the mUSD address to the mutex key that updates token balances and allowances, so that they are fetched when available (rather than waiting for the next block)