### PR TITLE
Clarify validation UX for overweight assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+Miscellaneous:
+
+- Improve and clarify UX for redeeming with a single asset when assets are overweight
+
 ## Version 1.5.0
 
 _Released 03.07.20 13.56 CEST_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 Miscellaneous:
 
-- Improve and clarify UX for redeeming with a single asset when assets are overweight
+- Improve and clarify UX for redeeming with a single asset when
+  assets are overweight
+- Improve and clarify UX for swapping and minting when assets are overweight
+  or their vault balances are exceeded
 
 ## Version 1.5.0
 
@@ -25,14 +28,14 @@ Miscellaneous:
 - Add Brave button to wallet connectors
 - Add migration for localStorage
 - Reduce wallet icon size
-- Identify and disable Dapper wallet (currently incompatible 
+- Identify and disable Dapper wallet (currently incompatible
   with `use-wallet` / `web3-react`)
 - Parse failing transaction errors to provide a more useful message
 - Default to 30 days for totals chart
 - Improve presentation of chart labels on different viewports
 - Fix order of volumes to match toggles
-- Clear the recently used wallet from local storage after disconnecting (so that 
-  users are not automatically reconnected on the next page load with the 
+- Clear the recently used wallet from local storage after disconnecting (so that
+  users are not automatically reconnected on the next page load with the
   previous wallet type)
 - Upgrade `use-wallet`
 - Remove `use-wallet` types (now in the package itself)
@@ -60,7 +63,7 @@ Bug fixes:
 Miscellaneous:
 
 - Change fetch policy for analytics data (first retrieve from cache, then network)
-- Capped APY chart values to avoid confusion 
+- Capped APY chart values to avoid confusion
 
 ## Version 1.3.0
 

--- a/src/components/core/ReactTooltip.tsx
+++ b/src/components/core/ReactTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useLayoutEffect } from 'react';
 import ReactTooltipBase from 'react-tooltip';
 import styled from 'styled-components';
 
@@ -11,6 +11,7 @@ export const ReactTooltip = styled(ReactTooltipBase)`
   padding: 4px 8px;
   font-size: ${FontSize.s};
   font-weight: bold;
+  max-width: 200px;
 `;
 
 const TooltipSpan = styled.span`
@@ -25,12 +26,18 @@ const TooltipSpan = styled.span`
   }
 `;
 
-export const Tooltip: FC<{ tip: string }> = ({ tip, children }) => {
-  ReactTooltipBase.rebuild();
+export const Tooltip: FC<{ tip: string; hideIcon?: boolean }> = ({
+  tip,
+  hideIcon,
+  children,
+}) => {
+  useLayoutEffect(() => {
+    ReactTooltipBase.rebuild();
+  }, []);
   return (
-    <TooltipSpan>
+    <TooltipSpan data-tip={tip} data-for="global">
       <span>{children}</span>
-      <img src={TooltipIcon} data-tip={tip} data-for="global" alt="" />
+      {hideIcon ? null : <img src={TooltipIcon} alt="" />}
     </TooltipSpan>
   );
 };

--- a/src/components/pages/Swap/getReasonMessage.ts
+++ b/src/components/pages/Swap/getReasonMessage.ts
@@ -1,0 +1,52 @@
+import { Reasons } from './types';
+import { BassetState, MassetState } from '../../../context/DataProvider/types';
+
+export const getReasonMessage = (
+  reason: Reasons | undefined,
+  affectedAsset?: BassetState | MassetState,
+): string | undefined => {
+  switch (reason) {
+    case undefined:
+      return undefined;
+    case Reasons.AssetNotAllowedInMint:
+      return 'Asset not allowed in mint';
+
+    case Reasons.AssetNotAllowedInSwap:
+      return 'Asset not allowed in swap';
+
+    case Reasons.TransferMustBeApproved:
+      return 'Transfer must be approved';
+
+    case Reasons.AmountExceedsBalance:
+      return 'Amount exceeds balance';
+
+    case Reasons.AmountMustBeGreaterThanZero:
+      return 'Amount must be greater than zero';
+
+    case Reasons.AmountMustBeSet:
+      return 'Amount must be set';
+
+    case Reasons.AssetsMustRemainBelowMaxWeight:
+      return `${affectedAsset?.symbol ||
+        'Asset'} must remain below its maximum weight; this limit helps to ensure diversification and reduce risk. Try using another asset.`;
+
+    case Reasons.CannotRedeemMoreAssetsThanAreInTheVault:
+      return `Cannot redeem more assets than are in the vault${
+        affectedAsset &&
+        (affectedAsset as BassetState | undefined)?.totalVaultInMasset
+          ? ` (${
+              affectedAsset.symbol
+            }: ${(affectedAsset as BassetState).totalVaultInMasset.format()})`
+          : ''
+      }`;
+
+    case Reasons.FetchingData:
+      return 'Fetching data';
+
+    case Reasons.AssetMustBeSelected:
+      return 'Asset must be selected';
+
+    default:
+      throw new Error('Unexpected reason');
+  }
+};

--- a/src/components/pages/Swap/types.ts
+++ b/src/components/pages/Swap/types.ts
@@ -48,9 +48,22 @@ export interface Dispatch {
   setQuantity(field: Fields, formValue: string): void;
 }
 
+export enum Reasons {
+  AmountMustBeGreaterThanZero,
+  AmountMustBeSet,
+  AssetNotAllowedInSwap,
+  CannotRedeemMoreAssetsThanAreInTheVault,
+  FetchingData,
+  AmountExceedsBalance,
+  AssetsMustRemainBelowMaxWeight,
+  TransferMustBeApproved,
+  AssetMustBeSelected,
+  AssetNotAllowedInMint,
+}
+
 export type ValidationResult = [
   boolean,
-  { [Fields.Input]?: string; [Fields.Output]?: string; applySwapFee?: boolean },
+  { [Fields.Input]?: Reasons; [Fields.Output]?: Reasons; applySwapFee?: boolean },
 ];
 
 export type StateValidator = (state: State) => ValidationResult;


### PR DESCRIPTION
- Improve and clarify UX for redeeming with a single asset when assets are overweight
- Improve and clarify UX for swapping and minting when assets are overweight
  or their vault balances are exceeded

TODO

- [x] Clarify UX/validation messages for swapping with overweight assets


Redeem single

![Screenshot from 2020-07-03 16-51-52](https://user-images.githubusercontent.com/5450382/86480079-a533fa80-bd4d-11ea-9bb5-d537cf4c51a3.png)

Swap - vault balance exceeded

![Screenshot from 2020-07-03 17-21-15](https://user-images.githubusercontent.com/5450382/86482412-2b524000-bd52-11ea-89cd-8b2d36789621.png)

Swap - overweight

![Screenshot from 2020-07-03 17-21-29](https://user-images.githubusercontent.com/5450382/86482417-2d1c0380-bd52-11ea-9c86-b4d21c6792d2.png)
