### PR TITLE
Transactions fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+Bug fixes:
+
+- Restrict getting historic transaction logs to just before mUSD was deployed (on mainnet)
+
 Miscellaneous:
 
 - Add support for Sentry.io error tracking service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Bug fixes:
 
 - Restrict getting historic transaction logs to just before mUSD was deployed (on mainnet)
+- Ensure that local transactions state is reset when changing account, or the activated account
+  changes, or the account is disconnected
 
 Miscellaneous:
 

--- a/src/context/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider.tsx
@@ -430,7 +430,7 @@ export const useOrderedHistoricTransactions = (): HistoricTransaction[] => {
 
 export const useHasPendingTransactions = (): boolean => {
   const { current } = useTransactionsState();
-  return !!Object.values(current).find(tx => tx.status !== 1);
+  return Object.values(current).some(tx => tx.status !== 1);
 };
 
 export const useHasPendingApproval = (
@@ -438,7 +438,7 @@ export const useHasPendingApproval = (
   spender: string,
 ): boolean => {
   const { current } = useTransactionsState();
-  return !!Object.values(current).find(
+  return Object.values(current).some(
     tx =>
       tx.status !== 1 &&
       tx.fn === 'approve' &&

--- a/src/updaters/contractsUpdater.ts
+++ b/src/updaters/contractsUpdater.ts
@@ -17,7 +17,7 @@ const fromBlock =
     : 0;
 
 export const ContractsUpdater = (): null => {
-  const { account } = useWallet();
+  const { account, activated, connected } = useWallet();
   const { addHistoric, reset } = useTransactionsDispatch();
 
   const mUsdContract = useMusdContract();
@@ -26,7 +26,7 @@ export const ContractsUpdater = (): null => {
   /**
    * When the account changes, reset the transactions state.
    */
-  useEffect(reset, [account, reset]);
+  useEffect(reset, [account, activated, connected, reset]);
 
   /**
    * When the account changes (and mUSD exists), get historic transactions.

--- a/src/updaters/contractsUpdater.ts
+++ b/src/updaters/contractsUpdater.ts
@@ -8,8 +8,13 @@ import {
   useSavingsContract,
 } from '../context/DataProvider/ContractsProvider';
 
-// TODO replace: when mUSD was deployed on Ropsten
-const fromBlock = process.env.REACT_APP_CHAIN_ID === '3' ? 7883370 : 0;
+// When mUSD was deployed
+const fromBlock =
+  process.env.REACT_APP_CHAIN_ID === '1'
+    ? 10152900
+    : process.env.REACT_APP_CHAIN_ID === '3'
+    ? 7883370
+    : 0;
 
 export const ContractsUpdater = (): null => {
   const { account } = useWallet();


### PR DESCRIPTION
- Restrict getting historic transaction logs to just before mUSD was deployed (on mainnet)
- Ensure that local transactions state is reset when changing account, or the activated account
  changes, or the account is disconnected
