### PR TITLE
Fix event listener for some injected wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+Bug fixes:
+
+- Ensure the 'network changed' event listener is not added for injected providers that
+  aren't event listeners.
+
 ## Version 1.5.2
 
 _Released 06.07.20 15.43 CEST_

--- a/src/context/AppProvider.tsx
+++ b/src/context/AppProvider.tsx
@@ -392,14 +392,14 @@ export const AppProvider: FC<{}> = ({ children }) => {
       } else {
         dispatch({ type: Actions.SetWalletSubType, payload: subType });
 
-        injected.on('networkChanged', networkChangedListener);
+        injected.on?.('networkChanged', networkChangedListener);
         injected.autoRefreshOnNetworkChange = false;
       }
     }
 
     return () => {
       if (injected && networkChangedListener) {
-        injected.removeListener('networkChanged', networkChangedListener);
+        injected.removeListener?.('networkChanged', networkChangedListener);
       }
     };
   }, [dispatch, activated, addErrorNotification]);


### PR DESCRIPTION
- Ensure the 'network changed' event listener is not added for injected providers that aren't event listeners.
- Sentry ID `1767659875`