### PR TITLE
Add custom key for Apollo cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_GRAPHQL_ENDPOINT=http://0.0.0.0:8000/subgraphs/name/mStable/mStable-protocol
-REACT_APP_GRAPHQL_ENDPOINT_WS=ws://0.0.0.0:8001/subgraphs/name/mStable/mStable-protocol
 REACT_APP_CHAIN_ID=3
 REACT_APP_PORTIS_DAPP_ID=
 REACT_APP_FORTMATIC_API_KEY_ROPSTEN=

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,5 @@
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/mstable/mstable-protocol
-REACT_APP_GRAPHQL_ENDPOINT_WS=wss://api.thegraph.com/subgraphs/name/mstable/mstable-protocol
 REACT_APP_CHAIN_ID=1
 REACT_APP_PORTIS_DAPP_ID=bd88165a-43d7-481f-91bb-7e2f21e95ce6
 REACT_APP_FORTMATIC_API_KEY_ROPSTEN=pk_test_4DEF7AB1F1B963B7

--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,5 @@
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/mstable/mstable-protocol-ropsten
-REACT_APP_GRAPHQL_ENDPOINT_WS=wss://api.thegraph.com/subgraphs/name/mstable/mstable-protocol-ropsten
 REACT_APP_CHAIN_ID=3
 REACT_APP_PORTIS_DAPP_ID=bd88165a-43d7-481f-91bb-7e2f21e95ce6
 REACT_APP_FORTMATIC_API_KEY_ROPSTEN=pk_test_4DEF7AB1F1B963B7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Bug fixes:
 
 - Ensure the 'network changed' event listener is not added for injected providers that
   aren't event listeners.
+- Ensure the Apollo cache is purged when the app version is changed or the app is
+  being run on a different chain.
 
 ## Version 1.5.2
 

--- a/src/context/AppProvider.tsx
+++ b/src/context/AppProvider.tsx
@@ -26,7 +26,7 @@ import {
   useAddInfoNotification,
   useAddErrorNotification,
 } from './NotificationsProvider';
-import { LocalStorage, Storage, StorageV0 } from '../localStorage';
+import { LocalStorage, Storage } from '../localStorage';
 
 enum Actions {
   ResetWallet,
@@ -267,8 +267,8 @@ export const AppProvider: FC<{}> = ({ children }) => {
   const resetWallet = useCallback<Dispatch['resetWallet']>(() => {
     deactivate();
     dispatch({ type: Actions.ResetWallet });
-    LocalStorage.removeItem<StorageV0, 'connectorId'>('connectorId');
-    LocalStorage.removeItem<Storage, 'connector'>('connector');
+    LocalStorage.removeItem<'connectorId'>('connectorId');
+    LocalStorage.removeItem<'connector'>('connector');
   }, [dispatch, deactivate]);
 
   const connectWallet = useCallback<Dispatch['connectWallet']>(
@@ -409,8 +409,7 @@ export const AppProvider: FC<{}> = ({ children }) => {
    */
   useEffect(() => {
     if (!attemptedReconnect.current && !(activating || connected)) {
-      const { id, subType } =
-        LocalStorage.get<Storage, 'connector'>('connector') || {};
+      const { id, subType } = LocalStorage.get('connector') || {};
       if (id) {
         connectWallet(id, subType);
       }
@@ -423,7 +422,7 @@ export const AppProvider: FC<{}> = ({ children }) => {
    */
   useEffect(() => {
     configureScope(scope => {
-      const connector = LocalStorage.get<Storage, 'connector'>('connector');
+      const connector = LocalStorage.get<'connector'>('connector');
       scope.setUser({
         id: account || 'NOT_CONNECTED',
       });

--- a/src/context/DataProvider/ApolloProvider.tsx
+++ b/src/context/DataProvider/ApolloProvider.tsx
@@ -12,6 +12,7 @@ import { persistCache } from 'apollo-cache-persist';
 import Skeleton from 'react-loading-skeleton';
 
 import { useAddErrorNotification } from '../NotificationsProvider';
+import { DAPP_VERSION } from '../../web3/constants';
 
 if (!process.env.REACT_APP_GRAPHQL_ENDPOINT) {
   throw new Error(
@@ -19,11 +20,9 @@ if (!process.env.REACT_APP_GRAPHQL_ENDPOINT) {
   );
 }
 
-if (!process.env.REACT_APP_GRAPHQL_ENDPOINT_WS) {
-  throw new Error(
-    'REACT_APP_GRAPHQL_ENDPOINT_WS environment variable not defined',
-  );
-}
+const CHAIN_ID = process.env.REACT_APP_CHAIN_ID;
+
+const CACHE_KEY = `apollo-cache-persist.CHAIN_ID_${CHAIN_ID}.DAPP_VERSION_${DAPP_VERSION}`;
 
 const cache = new InMemoryCache({
   resultCaching: true,
@@ -44,6 +43,7 @@ export const ApolloProvider: FC<{}> = ({ children }) => {
     persistCache({
       cache: cache as never,
       storage: window.localStorage as never,
+      key: CACHE_KEY,
     })
       // eslint-disable-next-line no-console
       .catch(error => console.warn('Cache persist error', error))

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -4,36 +4,48 @@ import { CONNECTORS } from './web3/constants';
 const STORAGE_PREFIX = '__mStable-app__';
 const STORAGE_VERSION = 1;
 
-interface BaseStorage {
-  version?: number;
-}
+type VersionedStorage<V extends number, T> = {
+  version: V;
+} & Omit<T, 'version'>;
 
-export interface StorageV0 extends BaseStorage {
+export interface StorageV0 extends VersionedStorage<0, {}> {
   connectorId?: keyof Connectors;
 }
 
-export interface StorageV1 extends BaseStorage {
-  version: 1;
+export interface StorageV1 extends VersionedStorage<1, {}> {
   connector?: { id: keyof Connectors; subType?: string };
 }
 
-export type AllStorage = StorageV0 | StorageV1;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface StorageV2 extends VersionedStorage<2, StorageV1> {
+  // Storage V2 goes here
+}
+
+export type AllStorage = StorageV0 & StorageV1 & StorageV2;
 
 export type Storage = Extract<AllStorage, { version: typeof STORAGE_VERSION }>;
 
-const getStorageKey = <S extends BaseStorage>(key: keyof S): string =>
-  `${STORAGE_PREFIX}.${key}`;
+const getStorageKey = (key: string): string => `${STORAGE_PREFIX}.${key}`;
 
 export const LocalStorage = {
-  set<S extends BaseStorage, T extends keyof S>(key: T, value: S[T]): void {
-    window.localStorage.setItem(getStorageKey<S>(key), JSON.stringify(value));
+  set<S extends Storage, T extends keyof S>(key: T, value: S[T]): void {
+    window.localStorage.setItem(
+      getStorageKey(key as string),
+      JSON.stringify(value),
+    );
   },
-  get<S extends BaseStorage, T extends keyof S>(key: T): S[T] {
-    const value = window.localStorage.getItem(getStorageKey<S>(key));
+  setVersion(version: number): void {
+    window.localStorage.setItem(
+      getStorageKey('version'),
+      JSON.stringify(version),
+    );
+  },
+  get<K extends keyof AllStorage>(key: K): AllStorage[K] {
+    const value = window.localStorage.getItem(getStorageKey(key));
     return value && value.length > 0 ? JSON.parse(value) : undefined;
   },
-  removeItem<S extends BaseStorage, T extends keyof S>(key: T): void {
-    window.localStorage.removeItem(getStorageKey<S>(key));
+  removeItem<K extends keyof AllStorage>(key: K): void {
+    window.localStorage.removeItem(getStorageKey(key as string));
   },
   clearAll(): void {
     window.localStorage.clear();
@@ -44,25 +56,25 @@ const migrateLocalStorage = (): void => {
   const version = LocalStorage.get('version');
 
   if (version === 0) {
-    const connectorId = LocalStorage.get<StorageV0, 'connectorId'>(
-      'connectorId',
-    );
+    const connectorId = LocalStorage.get<'connectorId'>('connectorId');
 
     if (connectorId) {
       // The injected connector now requires a subType (MetaMask/Brave/etc),
       // so we can't assume the type; these users will have to connect again.
       if (connectorId !== 'injected') {
         const subType = CONNECTORS.find(c => c.id === connectorId)?.subType;
-        LocalStorage.set<StorageV1, 'connector'>('connector', {
+        LocalStorage.set('connector', {
           id: connectorId,
           subType,
         });
       }
-      LocalStorage.removeItem<StorageV0, 'connectorId'>('connectorId');
+      LocalStorage.removeItem<'connectorId'>('connectorId');
     }
 
-    LocalStorage.set('version', 1);
+    LocalStorage.setVersion(1);
   }
+
+  LocalStorage.setVersion(STORAGE_VERSION);
 };
 
 (() => migrateLocalStorage())();


### PR DESCRIPTION
- Ensure the Apollo cache is purged when the app version is changed or the app is being run on a different chain.
- Removed unused env var `REACT_APP_GRAPHQL_ENDPOINT_WS`
- Clean up localStorage typing