### PR TITLE
Fix EARN APY calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+Bug fixes:
+
+- Fix EARN APY calculations and start with a narrow window for the preceding readings (16 hours previous)
+- Fix staking token price calculation
+
 ## Version 1.8.0
 
 _Released 03.08.20 15.30 CEST_
@@ -9,8 +14,8 @@ _Released 03.08.20 15.30 CEST_
 Features:
 
 - Add EARN feature
-  - This is a major change and includes new data sources and data 
-    processing, new contracts, a new top-level navigation item, 
+  - This is a major change and includes new data sources and data
+    processing, new contracts, a new top-level navigation item,
     and various components and forms.
   - Update `mStable-subgraph` submodule
   - Add another localStorage version
@@ -21,7 +26,6 @@ Features:
   - Improve layout for navigation items
 - Token approvals
   - Improve the token spending allowance UX with an amount field and infinite approve button
-
 
 Miscellaneous:
 

--- a/src/context/earn/useSyncedEarnData.ts
+++ b/src/context/earn/useSyncedEarnData.ts
@@ -24,7 +24,7 @@ interface CoingeckoPrices {
   [address: string]: { usd: number };
 }
 
-const START = Math.floor(Date.now() / 1e3) - 24 * 60 * 60;
+const START = Math.floor(Date.now() / 1e3) - 16 * 60 * 60;
 
 const useBlockTimestamp24hAgo = (): BlockTimestamp | undefined => {
   const query = useBlockTimestampQuery({
@@ -297,8 +297,11 @@ const getStakingTokenPrices = (normalizedPools: {
       [address]: BigDecimal.parse(
         tokens
           .reduce(
-            (total, token) =>
-              token.price ? token.liquidity.simple * token.price.simple : total,
+            (prev, current) =>
+              prev +
+              (current.price
+                ? current.liquidity.simple * current.price.simple
+                : 0),
             0,
           )
           .toString(),


### PR DESCRIPTION
- Fix EARN APY calculations and start with a narrow window for the preceding readings (16 hours previous)