### PR TITLE
Use exact full amount for 'max' in savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug fixes:
 - Ensure EARN APYs are available on first load
 - Link to the staking token on Etherscan on the pool card
 - Fix beta warning style
+- Ensure selecting 'max' when withdrawing mUSD savings uses the full amount in credits
 
 ## Version 1.8.1
 

--- a/src/components/pages/Save/reducer.ts
+++ b/src/components/pages/Save/reducer.ts
@@ -92,23 +92,17 @@ const reduce: Reducer<State, Action> = (state, action) => {
       }
 
       const {
-        savingsBalance: { balance },
-        latestExchangeRate: { exchangeRate } = {},
+        savingsBalance: { balance, credits },
       } = dataState.savingsContract;
 
       if (balance) {
         const formValue = balance.format(2, false);
         const amount = balance;
 
-        const amountInCredits =
-          amount && exchangeRate
-            ? amount.divPrecisely(exchangeRate)
-            : undefined;
-
         return {
           ...state,
           amount,
-          amountInCredits,
+          amountInCredits: credits,
           formValue,
           touched: !!formValue,
         };


### PR DESCRIPTION
- Ensure selecting 'max' when withdrawing mUSD savings uses the full amount in credits