### PR TITLE
Ensure EARN APYs are available on first load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+Bug fixes:
+
+- Link to the staking token on Etherscan on the pool card
+
 ## Version 1.8.1
 
 _Released 04.08.20 16.07 CEST_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Bug fixes:
 
+- Ensure EARN APYs are available on first load
 - Link to the staking token on Etherscan on the pool card
 - Fix beta warning style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bug fixes:
 
 - Link to the staking token on Etherscan on the pool card
+- Fix beta warning style
 
 ## Version 1.8.1
 

--- a/src/components/core/EtherscanLink.tsx
+++ b/src/components/core/EtherscanLink.tsx
@@ -5,7 +5,7 @@ import { ExternalLink } from './ExternalLink';
 
 const useEtherscanLink = (
   data: string,
-  type?: 'account' | 'transaction' | 'address',
+  type?: 'account' | 'transaction' | 'address' | 'token',
 ): string => useMemo(() => getEtherscanLink(data, type), [data, type]);
 
 /**
@@ -18,7 +18,7 @@ const useEtherscanLink = (
  */
 export const EtherscanLink: FC<{
   data: string;
-  type?: 'transaction' | 'account' | 'address';
+  type?: 'transaction' | 'account' | 'address' | 'token';
   truncate?: boolean;
   showData?: boolean;
 }> = ({ children, type = 'address', data, showData, truncate = true }) => (

--- a/src/components/layout/BetaWarning.tsx
+++ b/src/components/layout/BetaWarning.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useCallback, useState } from 'react';
 import styled from 'styled-components';
+import { centredLayout } from './css';
 
 const BETA_WARNING_KEY = 'acknowledged-beta-warning';
 
@@ -8,12 +9,15 @@ const Container = styled.div`
   border: 1px ${({ theme }) => theme.color.redTransparent} solid;
   border-radius: 3px;
   padding: ${({ theme }) => theme.spacing.s};
-  margin: ${({ theme }) => theme.spacing.m} 0;
+  margin: ${({ theme }) => theme.spacing.m};
   cursor: pointer;
+  ${centredLayout}
 `;
 
 export const BetaWarning: FC<{}> = () => {
-  const [hidden, setHidden] = useState(!!localStorage.getItem(BETA_WARNING_KEY));
+  const [hidden, setHidden] = useState(
+    !!localStorage.getItem(BETA_WARNING_KEY),
+  );
   const handleClick = useCallback(() => {
     try {
       localStorage.setItem(BETA_WARNING_KEY, Date.now().toString());
@@ -24,7 +28,7 @@ export const BetaWarning: FC<{}> = () => {
 
   return hidden ? null : (
     <Container onClick={handleClick}>
-      This project is in beta. Use at your own risk.
+      <div>This project is in beta. Use at your own risk.</div>
     </Container>
   );
 };

--- a/src/components/pages/Earn/Card.tsx
+++ b/src/components/pages/Earn/Card.tsx
@@ -178,8 +178,8 @@ export const Card: FC<Props> = ({ address, linkToPool }) => {
                       <ExternalLink href={platformLink}>{name}</ExternalLink>
                     </div>
                     <EtherscanLink
-                      data={stakingRewardsContract.address}
-                      type="address"
+                      data={stakingToken.address}
+                      type="token"
                       showData
                       truncate
                     />

--- a/src/components/pages/Earn/PoolsOverview.tsx
+++ b/src/components/pages/Earn/PoolsOverview.tsx
@@ -162,7 +162,7 @@ export const PoolsOverview: FC<{}> = () => {
                       format={NumberFormat.CountupPercentage}
                     />
                   ) : (
-                    'Awaiting 24h data'
+                    <Skeleton />
                   );
                 case Columns.WeeklyRewards:
                   return (

--- a/src/context/earn/useRawEarnData.ts
+++ b/src/context/earn/useRawEarnData.ts
@@ -15,7 +15,6 @@ export const useRawEarnData = ({
     {
       variables: { account, includeHistoric: !!block, block },
       fetchPolicy: 'cache-and-network',
-      partialRefetch: true,
     },
   );
 

--- a/src/web3/strings.ts
+++ b/src/web3/strings.ts
@@ -8,7 +8,10 @@ const ETHERSCAN_PREFIXES = {
   42: 'kovan.',
 };
 
-export const getEtherscanLink = (data: string, type?: string): string => {
+export const getEtherscanLink = (
+  data: string,
+  type?: 'account' | 'transaction' | 'address' | 'token',
+): string => {
   const prefix = `https://${ETHERSCAN_PREFIXES[
     CHAIN_ID as keyof typeof ETHERSCAN_PREFIXES
   ] || ETHERSCAN_PREFIXES[1]}etherscan.io`;
@@ -16,6 +19,8 @@ export const getEtherscanLink = (data: string, type?: string): string => {
   switch (type) {
     case 'transaction':
       return `${prefix}/tx/${data}`;
+    case 'token':
+      return `${prefix}/token/${data}`;
     case 'address':
     default:
       return `${prefix}/address/${data}`;


### PR DESCRIPTION
- Link to the staking token on Etherscan on the pool card
- Fix beta warning style 
- Ensure EARN APYs are available on first load
  - Ensure token prices are all fetched
  - Only fetch the token prices needed at any given time, and throttle the fetching properly
  - Update stale token prices (5 minutes)
  - Remove hardcoded tokens from token prices map
  - Do not calculate pool liquidity if token prices are missing
  - Use a skeleton fallback for missing APYs, which should now only be missing if the data is loading

