### PR TITLE
Add `scrollTo` for pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+Bug fixes:
+
+- When navigating to a pool from the pools overview, scroll to the top
+
+
 ## Version 1.8.2
 
 _Released 05.08.20 09.09 CEST_

--- a/src/components/pages/Earn/Pool/index.tsx
+++ b/src/components/pages/Earn/Pool/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useLayoutEffect } from 'react';
 import styled from 'styled-components';
 import Skeleton from 'react-loading-skeleton';
 
@@ -21,6 +21,10 @@ const Container = styled.div`
 
 export const PoolPage: FC<Props> = ({ slugOrAddress }) => {
   const address = useMatchStakingRewardsAddressFromUrl(slugOrAddress);
+
+  useLayoutEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, []);
 
   if (address === false) {
     return <>404</>;


### PR DESCRIPTION
- When navigating to a pool from the pools overview, scroll to the top

Resolves #122 