### PR TITLE
Support USDT token approval edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 Bug fixes:
 
 - When navigating to a pool from the pools overview, scroll to the top
-
+- Add handling for a transfer approval edge case with USDT in which the approved
+  amount must first be reset to zero before setting a new approved amount.
 
 ## Version 1.8.2
 

--- a/src/context/earn/useSyncedEarnData.ts
+++ b/src/context/earn/useSyncedEarnData.ts
@@ -93,6 +93,9 @@ const getUniqueTokens = (
   );
 
   return {
+    // MTA/BAL
+    '0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2': 18,
+    '0xba100000625a3754423978a60c9317c58a424e3d': 18,
     ...tokens,
     ...balancerTokens,
     ...uniswapTokens,


### PR DESCRIPTION
Add handling for a transfer approval edge case with USDT in which the approved amount must first be reset to zero before setting a new approved amount.

**Example**

Previously 1 USDT was approved:

![Screenshot from 2020-08-05 11-50-59](https://user-images.githubusercontent.com/5450382/89400967-e5074c80-d714-11ea-847d-f94be6e82e2f.png)

Increasing the amount beyond the approval adds the error and changes the approve buttons to 'reset approval'

![Screenshot from 2020-08-05 11-51-06](https://user-images.githubusercontent.com/5450382/89401012-f81a1c80-d714-11ea-9c1e-6a856dc55a6b.png)

Tooltip:

![Screenshot from 2020-08-05 11-51-47](https://user-images.githubusercontent.com/5450382/89401086-0ec07380-d715-11ea-80f6-ce3e389784bb.png)

Permission:

![Screenshot from 2020-08-05 11-53-13](https://user-images.githubusercontent.com/5450382/89401111-18e27200-d715-11ea-8e3c-582d705828b8.png)

Pending:

![Screenshot from 2020-08-05 11-53-28](https://user-images.githubusercontent.com/5450382/89401143-2697f780-d715-11ea-978f-bb7d91819044.png)

After successful reset tx:

![Screenshot from 2020-08-05 11-53-50](https://user-images.githubusercontent.com/5450382/89401204-3ca5b800-d715-11ea-81b8-d1fe56402994.png)

After setting the next approval (either infinite or exact)

![Screenshot from 2020-08-05 11-54-43](https://user-images.githubusercontent.com/5450382/89401219-42030280-d715-11ea-884c-7de0dffc4f61.png)
 
I think it's still important to keep the exact option available when minting with USDT; it should be clear that further approvals will require a reset for that token.
