### PR TITLE
Adjust decimal parsing and presentation of decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+Bug fixes:
+
+- Add extra decimals for pool shares and staked token balances (8 decimals total)
+- Adjust parsing and presentation of decimals for some browsers
+
 ## Version 1.8.3
 
 _Released 05.08.20 12.38 CEST_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 Bug fixes:
 
-- Add extra decimals for pool shares and staked token balances (8 decimals total)
 - Adjust parsing and presentation of decimals for some browsers
+- Add extra pool balance decimals
+- Add extra decimals for pool shares and staked token balances (8 decimals total)
+
+Miscellaneous:
+
+- Increase font size of submit buttons
 
 ## Version 1.8.3
 

--- a/src/components/core/Form.tsx
+++ b/src/components/core/Form.tsx
@@ -5,6 +5,7 @@ import {
   useIsSupportedChain,
   useIsWalletConnected,
 } from '../../context/AppProvider';
+import { FontSize } from '../../theme';
 import { Button } from './Button';
 
 interface Props {
@@ -80,6 +81,7 @@ export const SubmitButton = styled(Button)`
       disabled ? theme.color.blackTransparenter : theme.color.greenTransparent}
     0 10px 20px;
   transition: background-color 0.4s ease;
+  font-size: ${FontSize.l};
 
   &:hover {
     ${({ theme, disabled }) =>

--- a/src/components/pages/Earn/Pool/PoolBalances.tsx
+++ b/src/components/pages/Earn/Pool/PoolBalances.tsx
@@ -112,8 +112,8 @@ export const PoolBalances: FC<Props> = ({ className }) => {
               <LargeAmount
                 format={NumberFormat.CountupPercentage}
                 amount={stakingRewardsContract.stakingBalancePercentage}
-                countup={{ decimals: 6 }}
-                decimalPlaces={6}
+                countup={{ decimals: 8 }}
+                decimalPlaces={8}
               />
             </AmountContainer>
             <AmountContainer>
@@ -121,7 +121,7 @@ export const PoolBalances: FC<Props> = ({ className }) => {
               <Amount
                 format={NumberFormat.Countup}
                 amount={stakingRewardsContract.stakingBalance}
-                countup={{ decimals: 6 }}
+                countup={{ decimals: 8 }}
                 price={stakingToken.price}
               />
             </AmountContainer>

--- a/src/context/earn/transformEarnData.ts
+++ b/src/context/earn/transformEarnData.ts
@@ -81,7 +81,7 @@ const getStakingRewardsContractsMap = (
           (stakingBalance.exact.gt(0) && totalSupply.exact.gt(0)
             ? stakingBalance.simple / totalSupply.simple
             : 0
-          ).toFixed(18),
+          ).toFixed(20),
           stakingToken.decimals,
         );
 


### PR DESCRIPTION
Bug fixes:

- Adjust parsing and presentation of decimals for some browsers
- Add extra pool balance decimals
- Add extra decimals for pool shares and staked token balances (8 decimals total)

Miscellaneous:

- Increase font size of submit buttons
Example:

![Screenshot from 2020-08-06 10-32-09](https://user-images.githubusercontent.com/5450382/89509896-2c064800-d7d0-11ea-947c-97f8bd6b97b6.png)

Smallest amount that can be shown:

![Screenshot from 2020-08-06 10-34-06](https://user-images.githubusercontent.com/5450382/89510074-68d23f00-d7d0-11ea-8aeb-0787d00fd61f.png)

Max amount:

![Screenshot from 2020-08-06 10-35-20](https://user-images.githubusercontent.com/5450382/89510198-8d2e1b80-d7d0-11ea-8502-4f1d58dd3944.png)
