### PR TITLE
Handle edge cases for NaNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Features:
 - Provide a button for users to share a link to view their balances in a given pool
 - Provide a simple form on the pool view to input an address and view that user's balances
 
+Bug fixes:
+
+- Handle edge cases with non-numbers for counters
+
 ## Version 1.8.4
 
 _Released 06.08.20 14.29 CEST_

--- a/src/components/core/CountUp.tsx
+++ b/src/components/core/CountUp.tsx
@@ -41,14 +41,16 @@ export const CountUp: FC<Props> = ({
   separator = ',',
   duration = DEFAULT_DURATION,
 }) => {
-  const prevEnd = useRef<typeof end>(end);
+    // eslint-disable-next-line no-restricted-globals
+  const isValid = typeof end === 'number' && !isNaN(end);
+  const prevEnd = useRef(isValid ? end : 0);
   const isIdle = useIsIdle();
   const firstMount = useFirstMountState();
 
   const { countUp, update, pauseResume, start } = useCountUp({
     decimals,
     duration,
-    end,
+    end: isValid ? end : 0,
     separator,
     start: prevEnd.current,
     // ...(prefix ? { prefix } : null),
@@ -56,12 +58,12 @@ export const CountUp: FC<Props> = ({
   });
 
   useEffect(() => {
-    if (typeof end === 'number') {
+    if (isValid) {
       prevEnd.current = end;
       update(end);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [end]);
+  }, [end, isValid]);
 
   useEffect(() => {
     if (isIdle && !firstMount) {
@@ -76,7 +78,7 @@ export const CountUp: FC<Props> = ({
       highlightColor={highlightColor}
     >
       {prefix ? <PrefixOrSuffix>{prefix}</PrefixOrSuffix> : null}
-      <Number>{countUp}</Number>
+      <Number>{isValid ? countUp : '–'}</Number>
       {suffix ? <PrefixOrSuffix>{suffix}</PrefixOrSuffix> : null}
     </Container>
   );


### PR DESCRIPTION
- Handle edge cases for NaNs in `CountUp` components

From my testing, I couldn't replicate the scenario in which the savings APY was reported to be shown as NaN, but I also couldn't replicate the issue by passing different values through `parseFloat(formatUnits(bn, decimals))`, which is where the APY comes from. It's also not clear if this is a countup.js bug.

For now, this PR adds a guard to all counters for NaNs.

Valid value:

<img width="840" alt="Screenshot 2020-08-10 at 10 59 21" src="https://user-images.githubusercontent.com/5450382/89767965-393a7400-dafb-11ea-969b-90325892cda3.png">

Loading:

<img width="844" alt="Screenshot 2020-08-10 at 10 58 56" src="https://user-images.githubusercontent.com/5450382/89767971-3b043780-dafb-11ea-9f73-753f1496fd55.png">

NaN:

<img width="840" alt="Screenshot 2020-08-10 at 10 58 33" src="https://user-images.githubusercontent.com/5450382/89767974-3b9cce00-dafb-11ea-8e9a-862d62fedef8.png">


