### PR TITLE
Check MetaMask `isAuthorized` before eager activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Miscellaneous:
 Bug fixes:
 
 - Handle edge cases with non-numbers for counters
+- Before attempting to eagerly connect a previously-connected MetaMask account,
+  ensure that MetaMask is unlocked
 - Improve localStorage error handling
 
 ## Version 1.8.4

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "use-clipboard-copy": "^0.1.2",
     "use-deep-compare-effect": "^1.3.1",
     "use-onclickoutside": "^0.3.1",
-    "use-wallet": "^0.6.0",
+    "use-wallet": "^0.8.0",
     "utility-types": "^3.10.0",
     "victory-axis": "^34.3.6",
     "victory-bar": "^34.3.6",

--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -292,7 +292,8 @@ const WalletButton: FC<{}> = () => {
   const overlayItem = useOverlayItem();
   const toggleWallet = useToggleWallet();
   const resetWallet = useResetWallet();
-  const { connected } = useWallet<InjectedEthereum>();
+  const { status } = useWallet<InjectedEthereum>();
+  const connected = status === 'connected';
   const account = useOwnAccount();
   const connecting = useIsWalletConnecting();
   const truncatedAddress = useTruncatedAddress(account);

--- a/src/components/pages/Home/index.tsx
+++ b/src/components/pages/Home/index.tsx
@@ -173,7 +173,8 @@ const Carousel = styled.div`
 `;
 
 const Start: FC<{}> = () => {
-  const { connected } = useWallet();
+  const { status } = useWallet();
+  const connected = status === 'connected';
   const openWallet = useOpenWalletRedirect();
   const { alreadyAcked } = useContext(ctx);
   return (

--- a/src/components/wallet/Wallet.tsx
+++ b/src/components/wallet/Wallet.tsx
@@ -166,7 +166,8 @@ const Connected: FC<{ walletLabel: string; account: string }> = ({
 export const Wallet: FC<{}> = () => {
   const { error } = useWalletState();
   const connecting = useIsWalletConnecting();
-  const { connected, account } = useWallet();
+  const { status, account } = useWallet();
+  const connected = status === 'connected';
   const wallet = useWalletConnector();
 
   return (

--- a/src/context/UserProvider.tsx
+++ b/src/context/UserProvider.tsx
@@ -60,10 +60,8 @@ const AccountProvider: FC<{}> = ({ children }) => {
   );
 };
 
-export const UserProvider: FC<{}> = ({ children }) => {
-  return (
+export const UserProvider: FC<{}> = ({ children }) => (
     <UseWalletProvider chainId={CHAIN_ID} connectors={AVAILABLE_CONNECTORS}>
       <AccountProvider>{children}</AccountProvider>
     </UseWalletProvider>
   );
-};

--- a/src/updaters/contractsUpdater.ts
+++ b/src/updaters/contractsUpdater.ts
@@ -18,7 +18,8 @@ const fromBlock =
     : 0;
 
 export const ContractsUpdater = (): null => {
-  const { activated, connected } = useWallet();
+  const { status, connector } = useWallet();
+  const connected = status === 'connected';
   const account = useAccount();
   const { addHistoric, reset } = useTransactionsDispatch();
 
@@ -28,7 +29,7 @@ export const ContractsUpdater = (): null => {
   /**
    * When the account changes, reset the transactions state.
    */
-  useEffect(reset, [account, activated, connected, reset]);
+  useEffect(reset, [account, connector, connected, reset]);
 
   /**
    * When the account changes (and mUSD exists), get historic transactions.

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,15 @@
   dependencies:
     "@apollo/react-common" "^3.2.0-beta.1"
 
+"@aragon/provided-connector@^6.0.7":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@aragon/provided-connector/-/provided-connector-6.0.8.tgz#5d22ccb2a0ff599fbe6c23fdf96cb06d59ff2716"
+  integrity sha512-O7dPXPPwOulkF5Nc04nTEBQPtDmySRPtZW0SYQlX0CwjSAntfdyLjFr6T3bNFFqLCBKfDoW6Hc02fN+rClQGIg==
+  dependencies:
+    "@web3-react/abstract-connector" "^6.0.7"
+    "@web3-react/types" "^6.0.7"
+    tiny-warning "^1.0.3"
+
 "@ardatan/aggregate-error@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@ardatan/aggregate-error/-/aggregate-error-0.0.1.tgz#1403ac5de10d8ca689fc1f65844c27179ae1d44f"
@@ -14736,11 +14745,12 @@ use-onclickoutside@^0.3.1:
     are-passive-events-supported "^1.1.0"
     use-latest "^1.0.0"
 
-use-wallet@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/use-wallet/-/use-wallet-0.6.0.tgz#f4794cb6edccd19300f44975d1faa3749de5186e"
-  integrity sha512-Gva3QaUGnezWsHIaXxtLqSBjri4Ov4a79OqT0xhtWVOg1fP4KZVFRh1WL9TGxNiOuwlUh867kcO10/NSMECHnw==
+use-wallet@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/use-wallet/-/use-wallet-0.8.0.tgz#fc6277d2257af930a3235c40f551e737b187416a"
+  integrity sha512-+IWWSiOG4rj3zKOtb/7A9W2ys8ZdA+X8gUHNVc4/+qxEXwTo72M+qGplFCZLB6/+lH+oyQ6wL9fGNfyTLDt6AQ==
   dependencies:
+    "@aragon/provided-connector" "^6.0.7"
     "@web3-react/authereum-connector" "^6.1.1"
     "@web3-react/core" "^6.1.1"
     "@web3-react/fortmatic-connector" "^6.0.9"
@@ -14752,7 +14762,6 @@ use-wallet@^0.6.0:
     "@web3-react/walletconnect-connector" "^6.1.4"
     "@web3-react/walletlink-connector" "^6.1.1"
     jsbi "^3.1.1"
-    prop-types "^15.7.2"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
- Before attempting to eagerly connect a previously-connected MetaMask account, ensure that MetaMask is unlocked
- Update `use-wallet` to `0.8.0`

Change notes for `use-wallet`:

---


This version brings an API overhaul, making use-wallet easier to use across the board! Please note that this is a breaking change.
New API

With the new API exposed by use-wallet, boilerplate code is reduced to a minimum; all relevant state lives within the library itself you do not need to infer it for updating UI. The new spec is documented on the latest README.md. Here's the list of properties that we've deprecated:

    activate() and deactivate(): Replaced by connect() and reset(). This improves consistency with the ecosystem's conventions and also aligns with our latest naming decisions across our apps.

    activating and connected: Replaced by status, which contains the current status of the wallet connection in a string.

    isContract: Replaced by type, which will indicate if the account is a contract or not, in a string.

Apart from this, we've added some things which make using use-wallet a breeze, so, make sure to check the new spec out! If you'd like a pointer on how to use it, we have examples that will set you right on track.

Related issue: #28. Thanks @bpierre for the super fire new API spec!
