### PR TITLE
Handle localStorage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Miscellaneous:
 Bug fixes:
 
 - Handle edge cases with non-numbers for counters
+- Improve localStorage error handling
 
 ## Version 1.8.4
 

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-empty */
+
 import { Connectors } from 'use-wallet';
 import { CONNECTORS } from './web3/connectors';
 
@@ -27,27 +29,45 @@ export type Storage = Extract<AllStorage, { version: typeof STORAGE_VERSION }>;
 const getStorageKey = (key: string): string => `${STORAGE_PREFIX}.${key}`;
 
 export const LocalStorage = {
+  // It might not be possible to write to localStorage, e.g. in Incognito mode;
+  // ignore any get/set/clear errors.
   set<S extends Storage, T extends keyof S>(key: T, value: S[T]): void {
-    window.localStorage.setItem(
-      getStorageKey(key as string),
-      JSON.stringify(value),
-    );
+    const storageKey = getStorageKey(key as string);
+    const json = JSON.stringify(value);
+    try {
+      window.localStorage.setItem(storageKey, json);
+    } finally {
+    }
   },
   setVersion(version: number): void {
-    window.localStorage.setItem(
-      getStorageKey('version'),
-      JSON.stringify(version),
-    );
+    const storageKey = getStorageKey('version');
+    const json = JSON.stringify(version);
+    try {
+      window.localStorage.setItem(storageKey, json);
+    } finally {
+    }
   },
   get<K extends keyof AllStorage>(key: K): AllStorage[K] {
-    const value = window.localStorage.getItem(getStorageKey(key));
+    const storageKey = getStorageKey(key);
+    let value;
+    try {
+      value = window.localStorage.getItem(storageKey);
+    } finally {
+    }
     return value && value.length > 0 ? JSON.parse(value) : undefined;
   },
   removeItem<K extends keyof AllStorage>(key: K): void {
-    window.localStorage.removeItem(getStorageKey(key as string));
+    const storageKey = getStorageKey(key as string);
+    try {
+      window.localStorage.removeItem(storageKey);
+    } finally {
+    }
   },
   clearAll(): void {
-    window.localStorage.clear();
+    try {
+      window.localStorage.clear();
+    } finally {
+    }
   },
 };
 


### PR DESCRIPTION
- It might not be possible to write to localStorage, e.g. in Incognito mode; ignore any get/set/clear errors.
- Handles `QuotaExceededError`s