### PR TITLE
Adjust bAsset redemption toggle behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+Miscellaneous:
+
+- Adjust the behaviour of the redemption form such that when the
+  'redeem with all assets' toggle is selected, it is still possible
+  to toggle a bAsset to select it for single redemption.
+
 ## Version 1.8.5
 
 _Released 10.08.20 18.14 CEST_

--- a/src/components/pages/Redeem/reducer.ts
+++ b/src/components/pages/Redeem/reducer.ts
@@ -28,15 +28,18 @@ const reduce: Reducer<State, Action> = (state, action) => {
     }
 
     case Actions.ToggleBassetEnabled: {
-      if (state.mode !== Mode.RedeemSingle) return state;
-
       const address = action.payload;
 
-      return {
-        ...state,
-        touched: true,
-        bAssets: Object.values(state.bAssets).reduce((_bAssets, bAsset) => {
-          const enabled = bAsset.address === address ? !bAsset.enabled : false;
+      const bAssets = Object.values(state.bAssets).reduce(
+        (_bAssets, bAsset) => {
+          let enabled = false;
+
+          if (bAsset.address === address) {
+            // It should be enabled if switching from RedeemMasset;
+            // otherwise it should be toggled.
+            enabled = state.mode === Mode.RedeemMasset || !bAsset.enabled;
+          }
+
           return {
             ..._bAssets,
             [bAsset.address]: {
@@ -45,7 +48,16 @@ const reduce: Reducer<State, Action> = (state, action) => {
               amount: enabled ? bAsset.amount : undefined,
             },
           };
-        }, state.bAssets),
+        },
+        state.bAssets,
+      );
+
+      return {
+        ...state,
+        bAssets,
+        touched: true,
+        // In any case, toggling bAssets means redeeming single.
+        mode: Mode.RedeemSingle,
       };
     }
 


### PR DESCRIPTION
- Adjust the behaviour of the redemption form such that when the 'redeem with all assets' toggle is selected, it is still possible to toggle a bAsset to select it for single redemption.

![Peek 2020-08-11 09-57](https://user-images.githubusercontent.com/5450382/89872465-43bb4300-dbb9-11ea-9f57-7f87bf1ac5f0.gif)
