### PR TITLE
Ensure swap amount input has `approveAmount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+Bug fixes:
+
+- Fix a bug where the token approval button did not appear in the swap form.
+
 ## Version 1.8.6
 
 _Released 12.08.20 19.28 CEST_

--- a/src/components/pages/Swap/SwapInput.tsx
+++ b/src/components/pages/Swap/SwapInput.tsx
@@ -8,6 +8,7 @@ import { H3 } from '../../core/Typography';
 import { TokenAmountInput } from '../../forms/TokenAmountInput';
 import { Fields } from './types';
 import { useSwapDispatch, useSwapState } from './SwapProvider';
+import { BigDecimal } from '../../../web3/BigDecimal';
 
 export const SwapInput: FC<{}> = () => {
   const {
@@ -151,12 +152,21 @@ export const SwapInput: FC<{}> = () => {
     }
   }, [inputAddress, setToken, bAssets, touched]);
 
+  const approveAmount = useMemo(
+    () =>
+      input.amount.exact && input.token.decimals
+        ? new BigDecimal(input.amount.exact, input.token.decimals)
+        : undefined,
+    [input.amount, input.token.decimals],
+  );
+
   return (
     <>
       <FormRow>
         <H3>Send</H3>
         <TokenAmountInput
           amountValue={input.formValue}
+          approveAmount={approveAmount}
           tokenAddresses={inputAddresses}
           tokenValue={inputAddress}
           name={Fields.Input}


### PR DESCRIPTION
- Fix a bug where the token approval button did not appear in the swap form

![Peek 2020-08-14 12-12](https://user-images.githubusercontent.com/5450382/90239181-6d79a180-de27-11ea-8f2b-70985081e601.gif)
