### PR TITLE
Add `js.map` to static file types

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -3,7 +3,7 @@ runtime: nodejs10
 service: app
 
 handlers:
-  - url: /(.*\.(gif|png|svg|ttf|jpeg|jpg|css|css.map|js|pdf|scss|ico|json|json.map|mp4|webm))$
+  - url: /(.*\.(gif|png|svg|ttf|jpeg|jpg|css|css.map|js|js.map|pdf|scss|ico|json|json.map|mp4|webm))$
     static_files: build/\1
     secure: always
     upload: build/(.*)


### PR DESCRIPTION
Ensure the source maps are picked up by e.g. Sentry