### PR TITLE
Pool UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Next
 
+Bug fixes:
+
+- Show 'No data yet' for the APY of new EARN pools (<24h)
+- Hide the stake/claim/exit forms when viewing a pool as another address
+- Redirect back from a user's shared pool page when clicking 'reset'
+
+## Version 1.9.0
+
+_Released 17.08.20 13.44 CEST_
+
 Features:
 
 - Add support for redeeming with a custom selection of bAssets, so that users

--- a/src/components/pages/Earn/Card.tsx
+++ b/src/components/pages/Earn/Card.tsx
@@ -196,10 +196,16 @@ export const Card: FC<Props> = ({ address, linkToPool }) => {
                   </Heading>
                 </Tooltip>
                 <div>
-                  <StyledAmount
-                    format={NumberFormat.CountupPercentage}
-                    amount={stakingRewardsContract.combinedRewardsTokensApy}
-                  />
+                  {stakingRewardsContract.apy.waitingForData ? (
+                    <Tooltip tip="Calculating APY requires data from 24h ago, which is not available yet.">
+                      No data yet
+                    </Tooltip>
+                  ) : (
+                    <StyledAmount
+                      format={NumberFormat.CountupPercentage}
+                      amount={stakingRewardsContract.apy.value}
+                    />
+                  )}
                 </div>
               </div>
             </Row>

--- a/src/components/pages/Earn/Pool/PoolContent.tsx
+++ b/src/components/pages/Earn/Pool/PoolContent.tsx
@@ -6,6 +6,7 @@ import { ButtonLink } from '../../../core/Button';
 import { PoolForms } from './PoolForms';
 import { PoolBalances } from './PoolBalances';
 import { ImpermanentLossWarning } from './ImpermanentLossWarning';
+import { useIsMasquerading } from '../../../../context/UserProvider';
 
 const BackLink = styled(ButtonLink)`
   display: inline-block;
@@ -25,16 +26,23 @@ const Container = styled.div`
   width: 100%;
 `;
 
-export const PoolContent: FC<{ address: string }> = ({ address }) => (
-  <Container>
-    <BackLink href="/earn">Back</BackLink>
-    <CardContainer>
-      <Card address={address} />
-    </CardContainer>
-    <Content>
-      <PoolBalances />
-      <ImpermanentLossWarning />
-      <PoolForms address={address} />
-    </Content>
-  </Container>
-);
+export const PoolContent: FC<{ address: string }> = ({ address }) => {
+  const isMasquerading = useIsMasquerading();
+  return (
+    <Container>
+      <BackLink href="/earn">Back</BackLink>
+      <CardContainer>
+        <Card address={address} />
+      </CardContainer>
+      <Content>
+        <PoolBalances />
+        {isMasquerading ? null : (
+          <>
+            <ImpermanentLossWarning />
+            <PoolForms address={address} />
+          </>
+        )}
+      </Content>
+    </Container>
+  );
+};

--- a/src/components/pages/Earn/Pool/ViewAs.tsx
+++ b/src/components/pages/Earn/Pool/ViewAs.tsx
@@ -11,6 +11,7 @@ import { EtherscanLink } from '../../../core/EtherscanLink';
 import { Button } from '../../../core/Button';
 import { AddressInput } from './AddressInput';
 import { useCurrentStakingRewardsContract } from '../StakingRewardsContractProvider';
+import { getWorkingPath, navigate } from 'hookrouter';
 
 const Input = styled.div`
   display: flex;
@@ -57,8 +58,18 @@ export const ViewAs: FC<{}> = () => {
   }, [masquerade, address]);
 
   const handleResetMasquerade = useCallback(() => {
+    // Redirect to the normal path if needed
+    const path = getWorkingPath('');
+    if (account) {
+      const index = path.indexOf(`/${account}`);
+      if (index > 0) {
+        navigate(path.slice(0, index));
+      }
+    }
+
+    // Stop masquerading
     masquerade();
-  }, [masquerade]);
+  }, [masquerade, account]);
 
   const handleShare = useCallback(() => {
     if (earnUrl && account) {

--- a/src/components/pages/Earn/PoolsOverview.tsx
+++ b/src/components/pages/Earn/PoolsOverview.tsx
@@ -157,11 +157,15 @@ export const PoolsOverview: FC<{}> = () => {
                 //     />
                 //   );
                 case Columns.RewardsApy:
-                  return item.combinedRewardsTokensApy?.exact.gt(0) ? (
+                  return item.apy.value?.exact.gt(0) ? (
                     <ApyAmount
-                      amount={item.combinedRewardsTokensApy}
+                      amount={item.apy.value}
                       format={NumberFormat.CountupPercentage}
                     />
+                  ) : item.apy.waitingForData ? (
+                    <Tooltip tip="Calculating APY requires data from 24h ago, which is not available yet.">
+                      No data yet
+                    </Tooltip>
                   ) : (
                     <Skeleton />
                   );

--- a/src/context/earn/transformEarnData.ts
+++ b/src/context/earn/transformEarnData.ts
@@ -128,6 +128,9 @@ const getStakingRewardsContractsMap = (
           stakingBalance,
           stakingBalancePercentage,
           stakingReward,
+          apy: {
+            waitingForData: true,
+          },
           ...(type ===
             StakingRewardsContractType.StakingRewardsWithPlatformToken &&
           platformToken &&
@@ -174,7 +177,7 @@ const getStakingRewardsContractsMap = (
             : undefined),
         };
 
-        const combinedRewardsTokensApy = (() => {
+        const apyValue = (() => {
           const stakingTokenPrice = stakingToken?.price?.simple;
           const rewardsTokenPrice = rewardsToken?.price?.simple;
           const platformTokenPrice =
@@ -244,9 +247,12 @@ const getStakingRewardsContractsMap = (
           ..._state,
           [address]: {
             ...result,
-            combinedRewardsTokensApy: combinedRewardsTokensApy
-              ? new BigDecimal(combinedRewardsTokensApy.toString(), 18)
-              : undefined,
+            apy: {
+              value: apyValue
+                ? new BigDecimal(apyValue.toString(), 18)
+                : undefined,
+              waitingForData: !rewardPerTokenStored24hAgo,
+            },
           },
         };
       },

--- a/src/context/earn/types.ts
+++ b/src/context/earn/types.ts
@@ -94,8 +94,10 @@ export interface StakingRewardsContract {
   totalStakingRewards: BigDecimal;
   totalRemainingRewards: BigDecimal;
   type: StakingRewardsContractType;
-  stakingTokenApy?: BigDecimal;
-  combinedRewardsTokensApy?: BigDecimal;
+  apy: {
+    value?: BigDecimal;
+    waitingForData: boolean;
+  };
   platformRewards?: {
     platformRewardPerTokenStoredNow: BigNumber;
     platformRewardPerTokenStored24hAgo?: BigNumber;


### PR DESCRIPTION
- Show 'No data yet' for the APY of new EARN pools (<24h)
- Hide the stake/claim/exit forms when viewing a pool as another address
- Redirect back from a user's shared pool page when clicking 'reset'

Redirect (and hiding forms)

![forms-redirect](https://user-images.githubusercontent.com/5450382/90402073-36adc080-e09f-11ea-93ce-e021a0b9f825.gif)

APY no data on card

![apy-card](https://user-images.githubusercontent.com/5450382/90402075-37465700-e09f-11ea-9bad-89cd1d36001e.gif)

APY no data in list

![apy-pools-overview](https://user-images.githubusercontent.com/5450382/90402077-37deed80-e09f-11ea-9173-e8ea275b49ae.gif)




