### PR TITLE
Analytics UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Bug fixes:
 - Show 'No data yet' for the APY of new EARN pools (<24h)
 - Hide the stake/claim/exit forms when viewing a pool as another address
 - Redirect back from a user's shared pool page when clicking 'reset'
+- Analytics: Ensure y-axis numbers are not cut off on smaller viewports,
+  and use tabs for the date ranges
 
 ## Version 1.9.0
 

--- a/src/components/core/Tabs.tsx
+++ b/src/components/core/Tabs.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import { Button } from './Button';
+import { Color, FontSize } from '../../theme';
+
+export const TabsContainer = styled.div`
+  padding: 16px 0;
+  display: flex;
+  justify-content: space-evenly;
+`;
+
+export const TabBtn = styled(Button)<{ active: boolean }>`
+  background: transparent;
+  border-radius: 0;
+  border: 0;
+  border-top: 1px
+    ${({ active }) => (active ? Color.blueTransparent : Color.blackTransparent)}
+    solid;
+  border-bottom: 4px ${({ active }) => (active ? Color.blue : 'transparent')}
+    solid;
+  color: ${({ active }) => (active ? Color.blue : Color.black)};
+  font-size: ${FontSize.m};
+  text-transform: uppercase;
+  transition: all 0.2s ease;
+  width: 100%;
+`;

--- a/src/components/pages/Earn/Pool/PoolForms.tsx
+++ b/src/components/pages/Earn/Pool/PoolForms.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 
-import { Button } from '../../../core/Button';
-import { Color, FontSize } from '../../../../theme';
+import { TabsContainer, TabBtn } from '../../../core/Tabs';
+import { Color } from '../../../../theme';
 import { Tabs } from '../types';
 import {
   useStakingRewardContractDispatch,
@@ -17,28 +17,6 @@ const TAB_LABELS = {
   [Tabs.Claim]: 'Claim rewards',
   [Tabs.Exit]: 'Exit pool',
 };
-
-const TabsContainer = styled.div`
-  padding: 16px 0;
-  display: flex;
-  justify-content: space-evenly;
-`;
-
-const TabBtn = styled(Button)<{ active: boolean }>`
-  background: transparent;
-  border-radius: 0;
-  border: 0;
-  border-top: 1px
-    ${({ active }) => (active ? Color.blueTransparent : Color.blackTransparent)}
-    solid;
-  border-bottom: 4px ${({ active }) => (active ? Color.blue : 'transparent')}
-    solid;
-  color: ${({ active }) => (active ? Color.blue : Color.black)};
-  font-size: ${FontSize.m};
-  text-transform: uppercase;
-  transition: all 0.3s ease;
-  width: 100%;
-`;
 
 const TabButton: FC<{ tab: Tabs }> = ({ tab }) => {
   const { activeTab } = useStakingRewardsContractState();

--- a/src/components/stats/Metrics.tsx
+++ b/src/components/stats/Metrics.tsx
@@ -22,9 +22,9 @@ import {
 
 import { TimeMetricPeriod } from '../../graphql/mstable';
 import { ToggleInput } from '../forms/ToggleInput';
+import { TabsContainer, TabBtn } from '../core/Tabs';
 import { H3 } from '../core/Typography';
 import { Color, FontSize, ViewportWidth } from '../../theme';
-import { Button } from '../core/Button';
 
 export enum DateRange {
   Day,
@@ -73,24 +73,10 @@ interface Dispatch<T extends string> {
   toggleType(type: T): void;
 }
 
-const DateRangeButton = styled(Button)`
-  background: ${({ disabled }) => (disabled ? Color.white : 'transparent')};
-  color: ${({ disabled }) => (disabled ? Color.black : Color.blackTransparent)};
-`;
-
-const DateRanges = styled.div`
-  display: flex;
-  justify-content: space-between;
-  border: 1px ${Color.blackTransparenter} solid;
-  padding: 8px;
-
-  ${DateRangeButton} {
-    margin-right: 4px;
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
+const DateRangeBtn = styled(TabBtn)`
+  white-space: nowrap;
+  font-weight: normal;
+  font-size: 12px;
 `;
 
 const Control = styled.div`
@@ -111,7 +97,7 @@ const ControlsContainer = styled.div`
     justify-content: space-between;
 
     > :first-child {
-      flex-grow: 1;
+      flex: 1;
       margin-right: 16px;
     }
   }
@@ -143,7 +129,11 @@ const MetricToggles = styled.div`
   border: 1px ${Color.blackTransparenter} solid;
 `;
 
-const ChartContainer = styled.div``;
+const ChartContainer = styled.div`
+  svg {
+    overflow: visible;
+  }
+`;
 
 const Container = styled.div``;
 
@@ -279,18 +269,18 @@ export const Metrics = <T extends string>({
             </Control>
             <Control>
               <H3 borderTop>Range</H3>
-              <DateRanges>
+              <TabsContainer>
                 {state.dates.map(({ label, enabled, dateRange }) => (
-                  <DateRangeButton
+                  <DateRangeBtn
                     key={dateRange}
                     type="button"
                     onClick={() => setDateRange(dateRange)}
-                    disabled={!!enabled}
+                    active={!!enabled}
                   >
                     {label}
-                  </DateRangeButton>
+                  </DateRangeBtn>
                 ))}
-              </DateRanges>
+              </TabsContainer>
             </Control>
           </ControlsContainer>
           <ChartContainer>{children}</ChartContainer>


### PR DESCRIPTION
- Ensure y-axis numbers are not cut off on smaller viewports
- Use tabs for the date ranges

![Screenshot from 2020-08-17 15-59-45](https://user-images.githubusercontent.com/5450382/90404474-bc7f3b00-e0a2-11ea-8378-353a3dbff96b.png)
