### PR TITLE
Clarify redeem inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Bug fixes:
 
 - Show that BAL rewards will be received for the Balancer MTA/mUSD 95/5 pool
 
+Miscellaneous:
+
+- Make the inputs for redeeming with specific assets clearer, and add a
+  note explaining that assets to redeem must be selected and amounts entered.
+
 ## Version 1.9.1
 
 _Released 17.08.20 16.04 CEST_

--- a/src/components/core/Protip.tsx
+++ b/src/components/core/Protip.tsx
@@ -6,7 +6,7 @@ import { Color } from '../../theme';
 interface Props {
   className?: string;
   title?: string;
-  emoji?: string;
+  emoji?: string | null;
 }
 
 const ProtipLabel = styled.div`
@@ -36,7 +36,7 @@ export const Protip: FC<Props> = ({
 }) => (
   <Container className={className}>
     <ProtipLabel>
-      {title} <span>{emoji}</span>
+      {title} {emoji ? <span>{emoji}</span> : null}
     </ProtipLabel>
     <div>{children}</div>
   </Container>

--- a/src/components/forms/AmountInput.tsx
+++ b/src/components/forms/AmountInput.tsx
@@ -18,8 +18,12 @@ interface Props {
 
 const Input = styled.input<{ error: string | void; disabled?: boolean }>`
   appearance: none;
-  background: ${({ theme, error }) =>
-    error ? theme.color.redTransparenter : theme.color.white};
+  background: ${({ theme, error, disabled }) =>
+    error
+      ? theme.color.redTransparenter
+      : disabled
+      ? theme.color.blackTransparenter
+      : theme.color.white};
 
   border: ${({ theme, error, disabled }) =>
     `1px ${

--- a/src/components/pages/Redeem/RedeemInput.tsx
+++ b/src/components/pages/Redeem/RedeemInput.tsx
@@ -47,24 +47,6 @@ const ProtipContainer = styled.div<{ highlight: boolean }>`
   }
 `;
 
-const Item = styled.div<{ highlight?: boolean }>`
-  font-size: ${({ theme }) => theme.fontSize.s};
-  > :first-child {
-    text-transform: uppercase;
-    font-weight: bold;
-  }
-  ${({ highlight, theme }) =>
-    highlight
-      ? `
-    background: #ffeed2;
-    border: 2px ${theme.color.gold} dashed;
-    padding: 8px;
-    margin-left: -8px;
-    margin-right: -8px;
-  `
-      : ''}
-`;
-
 const BasketImpact = styled.div`
   display: flex;
   justify-content: space-between;
@@ -79,6 +61,13 @@ const BasketImpact = styled.div`
     }
   }
 `;
+
+const MassetInputGroup = styled.div`
+  > * {
+    margin-bottom: 8px;
+  }
+`;
+
 export const RedeemInput: FC<{}> = () => {
   const {
     amountInMasset,
@@ -120,8 +109,15 @@ export const RedeemInput: FC<{}> = () => {
       </ProtipContainer>
       <FormRow>
         <H3>Send mUSD</H3>
+        <RedeemMode>
+          <ToggleInput
+            onClick={toggleRedeemMasset}
+            checked={mode === Mode.RedeemMasset}
+          />
+          <span>Redeem with all assets proportionally</span>
+        </RedeemMode>
         {initialized && mAsset ? (
-          <>
+          <MassetInputGroup>
             <InlineTokenAmountInput
               amount={{
                 value: amountInMasset,
@@ -140,29 +136,25 @@ export const RedeemInput: FC<{}> = () => {
               }
               valid={touched ? valid : true}
             />
+            {mode === Mode.RedeemMasset ? null : (
+              <Protip title="Select assets below" emoji={null}>
+                To redeem with specific assets, select the assets and amounts to
+                receive below.
+              </Protip>
+            )}
             {feeAmount?.exact.gt(0) && valid ? (
-              <Item>
-                <div>Note</div>
-                <div>
-                  {mode === Mode.RedeemMasset ? 'Redemption' : 'Swap'} fee
-                  applies (see details below)
-                </div>
-              </Item>
+              <Protip title="Note" emoji={null}>
+                {mode === Mode.RedeemMasset ? 'Redemption' : 'Swap'} fee applies
+                (see details below)
+              </Protip>
             ) : null}
-          </>
+          </MassetInputGroup>
         ) : (
           <Skeleton />
         )}
       </FormRow>
       <FormRow>
         <H3>Receive assets</H3>
-        <RedeemMode>
-          <ToggleInput
-            onClick={toggleRedeemMasset}
-            checked={mode === Mode.RedeemMasset}
-          />
-          <span>Redeem with all assets proportionally</span>
-        </RedeemMode>
         <BassetInputs
           initialized={initialized}
           bAssets={bAssets}


### PR DESCRIPTION
- Make the inputs for redeeming with specific assets clearer, and add a note explaining that assets to redeem must be selected and amounts entered.

![Peek 2020-08-20 10-49](https://user-images.githubusercontent.com/5450382/90749112-54fc0200-e2d3-11ea-8514-f8069901013c.gif)
