### PR TITLE
Handle expired pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Next
 
+Miscellaneous:
+
+- Visually separate expired pools from current pools, and rewards information
+  associated with expired pools.
+- Disable the stake form for expired pools, and instruct users to instead
+  exit the pool.
+
 ## Version 1.9.2
 
 _Released 20.08.20 19.02 CEST_

--- a/src/components/pages/Earn/Card.tsx
+++ b/src/components/pages/Earn/Card.tsx
@@ -189,21 +189,25 @@ export const Card: FC<Props> = ({ address, linkToPool }) => {
                 </PlatformContainer>
               </div>
               <div>
-                <Tooltip tip="The Annual Percentage Yield is the extrapolated return on investment over the course of a year">
-                  <Heading>{rewardsToken.symbol} APY</Heading>
-                </Tooltip>
-                <div>
-                  {stakingRewardsContract.apy.waitingForData ? (
-                    <Tooltip tip="Calculating APY requires data from 24h ago, which is not available yet.">
-                      No data yet
+                {stakingRewardsContract.expired ? null : (
+                  <>
+                    <Tooltip tip="The Annual Percentage Yield is the extrapolated return on investment over the course of a year">
+                      <Heading>{rewardsToken.symbol} APY</Heading>
                     </Tooltip>
-                  ) : (
-                    <StyledAmount
-                      format={NumberFormat.CountupPercentage}
-                      amount={stakingRewardsContract.apy.value}
-                    />
-                  )}
-                </div>
+                    <div>
+                      {stakingRewardsContract.apy.waitingForData ? (
+                        <Tooltip tip="Calculating APY requires data from 24h ago, which is not available yet.">
+                          No data yet
+                        </Tooltip>
+                      ) : (
+                        <StyledAmount
+                          format={NumberFormat.CountupPercentage}
+                          amount={stakingRewardsContract.apy.value}
+                        />
+                      )}
+                    </div>
+                  </>
+                )}
               </div>
             </Row>
             <Row>
@@ -228,33 +232,38 @@ export const Card: FC<Props> = ({ address, linkToPool }) => {
                 </TokenAmounts>
               </div>
               <div>
-                <Tooltip tip="The weekly rewards made available to the pool">
-                  <Heading>Weekly rewards</Heading>
-                </Tooltip>
-                <TokenAmounts>
-                  <StyledTokenAmount
-                    amount={stakingRewardsContract.totalStakingRewards}
-                    format={NumberFormat.Abbreviated}
-                    symbol={rewardsToken.symbol}
-                    price={rewardsToken.price}
-                  />
-                  {stakingRewardsContract.platformRewards && platformToken ? (
-                    <Tooltip
-                      tip="Currently BAL rewards are airdropped based on Balancer's reward programme allocations."
-                      hideIcon
-                    >
-                      <StyledTokenAmount
-                        // amount={
-                        //   stakingRewardsContract.platformRewards
-                        //     ?.totalPlatformRewards
-                        // }
-                        format={NumberFormat.Abbreviated}
-                        symbol={platformToken.symbol}
-                        price={platformToken.price}
-                      />
+                {stakingRewardsContract.expired ? null : (
+                  <>
+                    <Tooltip tip="The weekly rewards made available to the pool">
+                      <Heading>Weekly rewards</Heading>
                     </Tooltip>
-                  ) : null}
-                </TokenAmounts>
+                    <TokenAmounts>
+                      <StyledTokenAmount
+                        amount={stakingRewardsContract.totalStakingRewards}
+                        format={NumberFormat.Abbreviated}
+                        symbol={rewardsToken.symbol}
+                        price={rewardsToken.price}
+                      />
+                      {stakingRewardsContract.platformRewards &&
+                      platformToken ? (
+                        <Tooltip
+                          tip="Currently BAL rewards are airdropped based on Balancer's reward programme allocations."
+                          hideIcon
+                        >
+                          <StyledTokenAmount
+                            // amount={
+                            //   stakingRewardsContract.platformRewards
+                            //     ?.totalPlatformRewards
+                            // }
+                            format={NumberFormat.Abbreviated}
+                            symbol={platformToken.symbol}
+                            price={platformToken.price}
+                          />
+                        </Tooltip>
+                      ) : null}
+                    </TokenAmounts>
+                  </>
+                )}
               </div>
             </Row>
           </Content>

--- a/src/components/pages/Earn/Pool/Stake.tsx
+++ b/src/components/pages/Earn/Pool/Stake.tsx
@@ -9,21 +9,27 @@ import {
   useSetFormManifest,
 } from '../../../forms/TransactionForm/FormProvider';
 import { TokenAmountInput } from '../../../forms/TokenAmountInput';
-import { H3 } from '../../../core/Typography';
+import { H3, P } from '../../../core/Typography';
 import {
+  useCurrentStakingRewardsContractCtx,
+  useCurrentStakingToken,
   useStakingRewardContractDispatch,
   useStakingRewardsContractState,
-  useCurrentStakingToken,
-  useCurrentStakingRewardsContractCtx,
 } from '../StakingRewardsContractProvider';
 import { CountUp } from '../../../core/CountUp';
 import { ExternalLink } from '../../../core/ExternalLink';
 import { PLATFORM_METADATA } from '../constants';
 import { Protip } from '../../../core/Protip';
+import { Tabs } from '../types';
 
 const Row = styled.div`
   width: 100%;
   padding-bottom: 16px;
+`;
+
+const ExitLink = styled.span`
+  border-bottom: 1px black solid;
+  cursor: pointer;
 `;
 
 const Input: FC<{}> = () => {
@@ -98,7 +104,9 @@ const Confirm: FC<{}> = () => {
 const Form: FC<{}> = () => {
   const {
     stake: { amount, valid },
+    stakingRewardsContract: { expired = false } = {},
   } = useStakingRewardsContractState();
+  const { setActiveTab } = useStakingRewardContractDispatch();
   const contract = useCurrentStakingRewardsContractCtx();
 
   const setFormManifest = useSetFormManifest();
@@ -119,7 +127,23 @@ const Form: FC<{}> = () => {
     }
   }, [setFormManifest, valid, amount, contract]);
 
-  return (
+  return expired ? (
+    <div>
+      <H3>Pool expired</H3>
+      <P>
+        This pool has now expired; new stakes should not be deposited, and the
+        pool should be{' '}
+        <ExitLink
+          onClick={() => {
+            setActiveTab(Tabs.Exit);
+          }}
+        >
+          exited
+        </ExitLink>
+        .
+      </P>
+    </div>
+  ) : (
     <TransactionForm
       confirmLabel="Stake"
       confirm={<Confirm />}

--- a/src/components/pages/Earn/Pool/ViewAs.tsx
+++ b/src/components/pages/Earn/Pool/ViewAs.tsx
@@ -2,6 +2,7 @@ import React, { FC, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { useClipboard } from 'use-clipboard-copy';
 
+import { getWorkingPath, navigate } from 'hookrouter';
 import {
   useAccount,
   useIsMasquerading,
@@ -11,7 +12,6 @@ import { EtherscanLink } from '../../../core/EtherscanLink';
 import { Button } from '../../../core/Button';
 import { AddressInput } from './AddressInput';
 import { useCurrentStakingRewardsContract } from '../StakingRewardsContractProvider';
-import { getWorkingPath, navigate } from 'hookrouter';
 
 const Input = styled.div`
   display: flex;

--- a/src/components/pages/Earn/index.tsx
+++ b/src/components/pages/Earn/index.tsx
@@ -253,10 +253,12 @@ const PoolCards: FC<{}> = () => {
       <PoolCardsContainer>
         <Slider
           setSwipeDisabled={setSwipeDisabled}
-          items={Object.keys(stakingRewardContracts).map(address => ({
-            children: <Card address={address} linkToPool />,
-            key: address,
-          }))}
+          items={Object.keys(stakingRewardContracts)
+            .filter(address => !stakingRewardContracts[address].expired)
+            .map(address => ({
+              children: <Card address={address} linkToPool />,
+              key: address,
+            }))}
         />
       </PoolCardsContainer>
     </Item>

--- a/src/context/earn/transformEarnData.ts
+++ b/src/context/earn/transformEarnData.ts
@@ -14,6 +14,10 @@ const BAL_REWARDS_EXCEPTIONS: string[] = [
   '0x0d4cd2c24a4c9cd31fcf0d3c4682d234d9f94be4', // MTA/mUSD 95/5
 ];
 
+const EXPIRED_POOLS: string[] = [
+  '0x25970282aac735cd4c76f30bfb0bf2bc8dad4e70', // MTA/mUSD 80/20
+];
+
 const getStakingRewardsContractsMap = (
   { pools, block24hAgo, tokenPrices }: SyncedEarnData,
   { rawStakingRewardsContracts }: RawEarnData,
@@ -129,6 +133,8 @@ const getStakingRewardsContractsMap = (
           .map(token => token.symbol)
           .join('/')} ${pool.tokens.map(token => token.ratio).join('/')}`;
 
+        const expired = EXPIRED_POOLS.includes(address);
+
         const result: StakingRewardsContract = {
           address,
           earnUrl,
@@ -139,6 +145,7 @@ const getStakingRewardsContractsMap = (
           duration,
           lastUpdateTime,
           periodFinish,
+          expired,
           stakingToken,
           rewardsToken,
           rewardRate: new BigNumber(rewardRate),

--- a/src/context/earn/types.ts
+++ b/src/context/earn/types.ts
@@ -82,6 +82,7 @@ export interface StakingRewardsContract {
   duration: number;
   lastUpdateTime: number;
   periodFinish: number;
+  expired: boolean;
   rewardRate: BigNumber;
   rewardPerTokenStoredNow: BigNumber;
   rewardPerTokenStored24hAgo?: BigNumber;


### PR DESCRIPTION
- Visually separate expired pools from current pools, and rewards information associated with expired pools.
- Disable the stake form for expired pools, and instruct users to instead exit the pool.

List

![Screenshot from 2020-08-24 14-29-16](https://user-images.githubusercontent.com/5450382/91046545-e98a9b00-e618-11ea-904c-7a67af76ed21.png)

Form

![Screenshot from 2020-08-24 14-41-58](https://user-images.githubusercontent.com/5450382/91046542-e8f20480-e618-11ea-9597-df2cb14c63eb.png)

Card

![Screenshot from 2020-08-24 14-49-14](https://user-images.githubusercontent.com/5450382/91046593-01fab580-e619-11ea-900f-9f216ff04073.png)

