### PR TITLE
Use closest APY data-points for daily APY chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 Miscellaneous:
 
 - Remove redundant information about BAL rewards for claim and withdraw confirmations
+- Use closest APY data-points for daily APY chart for each day (i.e. ensure the x-axis lines up)
 
 ## Version 1.10.0
 

--- a/src/components/pages/Analytics/index.tsx
+++ b/src/components/pages/Analytics/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useLayoutEffect } from 'react';
 import styled from 'styled-components';
 import Skeleton from 'react-loading-skeleton';
 
@@ -105,60 +105,66 @@ const ThirdPartySources = styled.ul`
   }
 `;
 
-export const Analytics: FC<{}> = () => (
-  <div>
-    <PageHeader
-      icon={<AnalyticsIcon />}
-      title="Analytics"
-      subtitle="Explore activity across mStable"
-    />
-    <Section id="save">
-      <H2 borderTop>APY</H2>
-      <HistoricalApy />
-    </Section>
-    <Section id="volumes">
-      <H2 borderTop>Volumes</H2>
-      <P size={Size.s}>All values in mUSD</P>
-      <VolumeChart />
-    </Section>
-    <Section id="totals">
-      <H2 borderTop>Totals</H2>
-      <P size={Size.s}>All values in mUSD</P>
-      <NiceBigNumbers>
-        <TotalSupply />
-        <TotalSavings />
-      </NiceBigNumbers>
-      <AggregateChart />
-    </Section>
-    <Section id="basket">
-      <H2 borderTop>Basket share</H2>
-      <BasketStatsContainer>
-        <BasketStats />
-      </BasketStatsContainer>
-    </Section>
-    <Section id="third-party">
-      <H2 borderTop>Other sources</H2>
-      <P>Learn more by exploring these third-party sources:</P>
-      <ThirdPartySources>
-        <li>
-          <a
-            href="https://etherscan.io/token/0xe2f2a5c287993345a840db3b0845fbc70f5935a5#tokenAnalytics"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            mUSD on Etherscan
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://thegraph.com/explorer/subgraph/mstable/mstable-protocol"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            mStable Subgraph explorer
-          </a>
-        </li>
-      </ThirdPartySources>
-    </Section>
-  </div>
-);
+export const Analytics: FC<{}> = () => {
+  useLayoutEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, []);
+
+  return (
+    <div>
+      <PageHeader
+        icon={<AnalyticsIcon />}
+        title="Analytics"
+        subtitle="Explore activity across mStable"
+      />
+      <Section id="save">
+        <H2 borderTop>APY</H2>
+        <HistoricalApy />
+      </Section>
+      <Section id="volumes">
+        <H2 borderTop>Volumes</H2>
+        <P size={Size.s}>All values in mUSD</P>
+        <VolumeChart />
+      </Section>
+      <Section id="totals">
+        <H2 borderTop>Totals</H2>
+        <P size={Size.s}>All values in mUSD</P>
+        <NiceBigNumbers>
+          <TotalSupply />
+          <TotalSavings />
+        </NiceBigNumbers>
+        <AggregateChart />
+      </Section>
+      <Section id="basket">
+        <H2 borderTop>Basket share</H2>
+        <BasketStatsContainer>
+          <BasketStats />
+        </BasketStatsContainer>
+      </Section>
+      <Section id="third-party">
+        <H2 borderTop>Other sources</H2>
+        <P>Learn more by exploring these third-party sources:</P>
+        <ThirdPartySources>
+          <li>
+            <a
+              href="https://etherscan.io/token/0xe2f2a5c287993345a840db3b0845fbc70f5935a5#tokenAnalytics"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              mUSD on Etherscan
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://thegraph.com/explorer/subgraph/mstable/mstable-protocol"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              mStable Subgraph explorer
+            </a>
+          </li>
+        </ThirdPartySources>
+      </Section>
+    </div>
+  );
+};

--- a/src/components/stats/DailyApys.tsx
+++ b/src/components/stats/DailyApys.tsx
@@ -5,7 +5,7 @@ import { VictoryLine } from 'victory-line';
 import { VictoryChart } from 'victory-chart';
 import { VictoryAxis } from 'victory-axis';
 import Skeleton from 'react-loading-skeleton';
-import { endOfHour, fromUnixTime, subDays } from 'date-fns';
+import { endOfHour, fromUnixTime, subDays, closestTo } from 'date-fns';
 
 import { useDailyApysForPastWeek } from '../../web3/hooks';
 import { Color } from '../../theme';
@@ -36,17 +36,19 @@ export const DailyApys: FC<{}> = () => {
   const data = useMemo<{ x: Date; y: number }[]>(
     () =>
       dailyApys
-        .filter(a => a.value && a.end)
-        .map(({ value, end }) => {
+        .filter(a => a.value && a.start)
+        .map(({ value, start }) => {
           const percentage = parseFloat(formatUnits(value as BigNumber, 16));
+          const startTime = fromUnixTime(start as number);
+
           return {
-            x: fromUnixTime(end as number),
+            x: closestTo(startTime, tickValues),
             y: percentage,
             percentage,
           };
         }),
 
-    [dailyApys],
+    [dailyApys, tickValues],
   );
 
   return (


### PR DESCRIPTION
- For the daily APY chart, map the x axis of each data-point to the closest tick value, so that they line up correctly

![image](https://user-images.githubusercontent.com/5450382/92612357-1649de00-f2ba-11ea-94db-73224fb8c0d2.png)
