### PR TITLE
Removed the countup functionality from the Save Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+Features:
+
+- Savings balance value now increases only when interest accrues, rather than a conservative (but notional) increase in real time
+
 ## Version 1.11.0
 
 _Released 04.09.20 15.00 CEST_

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -9,10 +9,10 @@ import { FontSize } from '../../../theme';
 import {
   // useApyForPast24h,
   useAverageApyForPastWeek,
-  useIncreasingNumber,
 } from '../../../web3/hooks';
 import { useSavingsBalance } from '../../../context/DataProvider/DataProvider';
 import { AnalyticsLink } from '../Analytics/AnalyticsLink';
+import { Amount, NumberFormat } from '../../core/Amount';
 
 const CreditBalance = styled.div`
   img {
@@ -91,27 +91,17 @@ export const SaveInfo: FC<{}> = () => {
   );
 
   const savingsBalance = useSavingsBalance();
-  const clampedBalance =
-    savingsBalance?.balance?.simple || 0 > 500
-      ? 500
-      : savingsBalance?.balance?.simple || 0;
-
-  const savingsBalanceIncreasing = useIncreasingNumber(
-    savingsBalance?.balance?.simple || 0,
-    // TODO - re-introduce real APY after it settles down
-    // ((savingsBalance.simple || 0) * (apyPercentage || 10)) /
-    (clampedBalance * 10) / 100 / 365 / 24 / 60 / 60 / 10,
-    100,
-  );
-
-  return (
+   return (
     <>
       <BalanceInfoRow>
         <div>
           <H3>Your mUSD savings balance</H3>
           <CreditBalance>
             <MUSDIconTransparent />
-            <CountUp end={savingsBalanceIncreasing || 0} decimals={7} />
+            <Amount
+            format={NumberFormat.Simple}
+            amount={savingsBalance?.balance}
+            />
             <InfoMsg>
               This amount includes notional interest. For more information{' '}
               <a

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../../web3/hooks';
 import { useSavingsBalance } from '../../../context/DataProvider/DataProvider';
 import { AnalyticsLink } from '../Analytics/AnalyticsLink';
-import { Amount, NumberFormat } from '../../core/Amount';
 
 const CreditBalance = styled.div`
   img {
@@ -98,10 +97,7 @@ export const SaveInfo: FC<{}> = () => {
           <H3>Your mUSD savings balance</H3>
           <CreditBalance>
             <MUSDIconTransparent />
-            <Amount
-            format={NumberFormat.Simple}
-            amount={savingsBalance?.balance}
-            />
+            <CountUp end={savingsBalance?.balance?.simple || 0} decimals={7} />
             <InfoMsg>
               This amount includes notional interest. For more information{' '}
               <a

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -99,13 +99,13 @@ export const SaveInfo: FC<{}> = () => {
             <MUSDIconTransparent />
             <CountUp end={savingsBalance?.balance?.simple || 0} decimals={7} />
             <InfoMsg>
-              This amount includes notional interest. For more information{' '}
+              See how interest is calculated{' '}
               <a
                 href="https://docs.mstable.org/mstable-assets/massets/native-interest-rate#savings-balance-increase"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                see here
+                here
               </a>
               .
             </InfoMsg>


### PR DESCRIPTION
- The `savings balance`  amount on the Save Page does not have a constant increasing value but an increasing value over time depending on when interest accrues.

-  Updated the info message displayed under the `savings balance` to reflect the new change
