### PR TITLE
Use mainnet Balancer subgraph for Ropsten

### DIFF
--- a/.env.example.ropsten
+++ b/.env.example.ropsten
@@ -1,8 +1,8 @@
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_GRAPHQL_ENDPOINT_MSTABLE=https://api.thegraph.com/subgraphs/name/mstable/mstable-protocol-ropsten
 
-# Not actively maintained at the moment
-REACT_APP_GRAPHQL_ENDPOINT_BALANCER=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-ropsten
+# This is mainnet: no Balancer Ropsten subgraph is actively maintained at the moment
+REACT_APP_GRAPHQL_ENDPOINT_BALANCER=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer
 
 # This is mainnet: no Uniswap Ropsten subgraph is actively maintained at the moment
 REACT_APP_GRAPHQL_ENDPOINT_UNISWAP=https://api.thegraph.com/subgraphs/name/ianlapham/uniswapv2


### PR DESCRIPTION
- Use the mainnet Balancer subgraph for Ropsten, because the Ropsten version is not actively maintained and breaks the app

Fixes #182