### PR TITLE
Fixed custom transaction price unit

### DIFF
--- a/src/components/forms/TransactionForm/GasPrice.tsx
+++ b/src/components/forms/TransactionForm/GasPrice.tsx
@@ -147,12 +147,13 @@ export const GasPrice: FC<Props> = () => {
     currentGasPrice &&
     ethPrice &&
     manifest?.gasLimit
-      ? currentGasPrice * (ethPrice / 1e9) * manifest.gasLimit.toNumber()
+      ? (currentGasPrice / 1e9) *
+        (ethPrice / 1e9) *
+        manifest.gasLimit.toNumber()
       : undefined;
-
   const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
     event => {
-      setGasPrice(parseFloat(event.target.value));
+      setGasPrice(parseFloat(event.target.value) * 1e9);
     },
     [setGasPrice],
   );


### PR DESCRIPTION
- The custom gas price was sent in wei instead of gwei so the fee calculation as well as `handleChange` had to be fixed