### PR TITLE
Produce full and simple report from `platformRewards` and output Merkle root hash

### DIFF
--- a/scripts/merkleRootHash.ts
+++ b/scripts/merkleRootHash.ts
@@ -56,15 +56,10 @@ const getAllocations = async (
   );
 };
 
-export const main = async () => {
-  const { argv } = options({
-    token: { type: 'string', demandOption: true },
-    trancheNumber: { type: 'number', demandOption: true },
-  });
-
-  const token = argv.token.toLowerCase();
-  const { trancheNumber } = argv;
-
+export const getMerkleRootHash = async (
+  trancheNumber: number,
+  token: string,
+) => {
   const allocations = await getAllocations(trancheNumber, token);
 
   const elements = Object.entries(allocations).map(([account, amount]) =>
@@ -94,4 +89,16 @@ export const main = async () => {
   };
 
   console.log(JSON.stringify(output, null, 2));
+};
+
+export const main = async () => {
+  const { argv } = options({
+    token: { type: 'string', demandOption: true },
+    trancheNumber: { type: 'number', demandOption: true },
+  });
+
+  const token = argv.token.toLowerCase();
+  const { trancheNumber } = argv;
+
+  await getMerkleRootHash(trancheNumber, token);
 };

--- a/scripts/utils/outputJsonReport.ts
+++ b/scripts/utils/outputJsonReport.ts
@@ -3,22 +3,31 @@ import fs from 'fs';
 
 export interface JsonReport {
   dirName: string;
-  fileName: string;
-  data: object;
+  fullOutputReportFileName: string;
+  simpleOutputReportFileName: string;
+  fullOutputReport: object;
+  simpleOutputReport: object;
 }
 
 export const outputJsonReport = async ({
   dirName,
-  fileName,
-  data,
-}: JsonReport): Promise<string> => {
-  const content = JSON.stringify(data, null, 2);
-
+  fullOutputReportFileName,
+  simpleOutputReportFileName,
+  fullOutputReport,
+  simpleOutputReport,
+}: JsonReport): Promise<string[]> => {
+  const fullOutputReportContent = JSON.stringify(fullOutputReport, null, 2);
+  const simpleOutputReportContent = JSON.stringify(simpleOutputReport, null, 2);
   const dirPath = path.join('public', 'reports', dirName);
   await fs.promises.mkdir(dirPath, { recursive: true });
 
-  const fullPath = `${dirPath}/${fileName}.json`;
-  await fs.promises.writeFile(fullPath, content);
+  const fullOutputReportPath = `${dirPath}/${fullOutputReportFileName}.json`;
+  const simpleOutputReportPath = `${dirPath}/${simpleOutputReportFileName}.json`;
+  await fs.promises.writeFile(fullOutputReportPath, fullOutputReportContent);
+  await fs.promises.writeFile(
+    simpleOutputReportPath,
+    simpleOutputReportContent,
+  );
 
-  return fullPath;
+  return [fullOutputReportPath, simpleOutputReportPath];
 };

--- a/scripts/utils/outputJsonReport.ts
+++ b/scripts/utils/outputJsonReport.ts
@@ -3,31 +3,22 @@ import fs from 'fs';
 
 export interface JsonReport {
   dirName: string;
-  fullOutputReportFileName: string;
-  simpleOutputReportFileName: string;
-  fullOutputReport: object;
-  simpleOutputReport: object;
+  fileName: string;
+  data: object;
 }
 
 export const outputJsonReport = async ({
   dirName,
-  fullOutputReportFileName,
-  simpleOutputReportFileName,
-  fullOutputReport,
-  simpleOutputReport,
-}: JsonReport): Promise<string[]> => {
-  const fullOutputReportContent = JSON.stringify(fullOutputReport, null, 2);
-  const simpleOutputReportContent = JSON.stringify(simpleOutputReport, null, 2);
+  fileName,
+  data,
+}: JsonReport): Promise<string> => {
+  const content = JSON.stringify(data, null, 2);
+
   const dirPath = path.join('public', 'reports', dirName);
   await fs.promises.mkdir(dirPath, { recursive: true });
 
-  const fullOutputReportPath = `${dirPath}/${fullOutputReportFileName}.json`;
-  const simpleOutputReportPath = `${dirPath}/${simpleOutputReportFileName}.json`;
-  await fs.promises.writeFile(fullOutputReportPath, fullOutputReportContent);
-  await fs.promises.writeFile(
-    simpleOutputReportPath,
-    simpleOutputReportContent,
-  );
+  const fullPath = `${dirPath}/${fileName}.json`;
+  await fs.promises.writeFile(fullPath, content);
 
-  return [fullOutputReportPath, simpleOutputReportPath];
+  return fullPath;
 };

--- a/scripts/vaultBreakdown.ts
+++ b/scripts/vaultBreakdown.ts
@@ -98,10 +98,8 @@ export const main = async () => {
 
   const files = await outputJsonReport({
     dirName: 'vault-breakdown',
-    fullOutputReportFileName: `${startTime}-${endTime}`,
-    simpleOutputReportFileName: `${startTime}-${endTime}`,
-    fullOutputReport: balances,
-    simpleOutputReport: balances,
+    fileName: `${startTime}-${endTime}`,
+    data: balances,
   });
 
   console.log(`Created files: ${files}`);

--- a/scripts/vaultBreakdown.ts
+++ b/scripts/vaultBreakdown.ts
@@ -96,11 +96,13 @@ export const main = async () => {
   const startTime = balances.dates[0].getTime();
   const endTime = balances.dates[balances.dates.length - 1].getTime();
 
-  const file = await outputJsonReport({
+  const files = await outputJsonReport({
     dirName: 'vault-breakdown',
-    fileName: `${startTime}-${endTime}`,
-    data: balances,
+    fullOutputReportFileName: `${startTime}-${endTime}`,
+    simpleOutputReportFileName: `${startTime}-${endTime}`,
+    fullOutputReport: balances,
+    simpleOutputReport: balances,
   });
 
-  console.log(`Created file: ${file}`);
+  console.log(`Created files: ${files}`);
 };

--- a/src/__tests__/platformRewards.test.ts
+++ b/src/__tests__/platformRewards.test.ts
@@ -4,9 +4,10 @@ import { parseUnits } from 'ethers/utils';
 
 import {
   mod,
-  generateReport,
+  generateReportData,
   PlatformEarningsReport,
 } from '../../scripts/platformRewards';
+import { JsonReport } from '../../scripts/utils/outputJsonReport';
 
 describe('platformRewards', () => {
   const acct1 = {
@@ -232,9 +233,9 @@ describe('platformRewards', () => {
     jest.spyOn(mod, 'parseArgs').mockImplementation(async () => args);
 
     const {
-      data: { mtaEarnings, rewards, totalRewards },
-    } = (await generateReport()) as {
-      data: PlatformEarningsReport;
+      fullOutputReport: { mtaEarnings, rewards, totalRewards },
+    } = (await generateReportData()) as {
+      fullOutputReport: PlatformEarningsReport;
     };
 
     expect(totalRewards).toEqual('1000.0');
@@ -263,9 +264,9 @@ describe('platformRewards', () => {
     mockFetchAllData(DATA.twoStakers);
 
     const {
-      data: { mtaEarnings, rewards },
-    } = (await generateReport()) as {
-      data: PlatformEarningsReport;
+      fullOutputReport: { mtaEarnings, rewards },
+    } = (await generateReportData()) as {
+      fullOutputReport: PlatformEarningsReport;
     };
 
     // Two stakers

--- a/src/__tests__/platformRewards.test.ts
+++ b/src/__tests__/platformRewards.test.ts
@@ -7,7 +7,6 @@ import {
   generateReportData,
   PlatformEarningsReport,
 } from '../../scripts/platformRewards';
-import { JsonReport } from '../../scripts/utils/outputJsonReport';
 
 describe('platformRewards', () => {
   const acct1 = {


### PR DESCRIPTION
- Removed `fullOutput` option: the full report and the mapping of stakers are now created as separate files when the script is run
- The Merkle root hash is also generated and output to the console 