### PR TITLE
Adjust Save view to reflect available Save contracts

### DIFF
--- a/src/components/core/Toggle.tsx
+++ b/src/components/core/Toggle.tsx
@@ -1,0 +1,48 @@
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+import Skeleton from 'react-loading-skeleton';
+import { BubbleButton } from './Button';
+
+interface Props {
+  className?: string;
+  disabled?: boolean;
+  activeIndex?: number;
+  titles?: string[];
+  onClick: (index: number) => void;
+}
+
+const Container = styled.div`
+  padding: 0;
+  border-radius: 1.5rem;
+  background: #eee;
+
+  button:nth-last-child(1) {
+    margin-left: -0.5rem;
+  }
+`;
+
+export const Toggle: FC<Props> = props => {
+  const { className, titles, activeIndex, onClick } = props;
+  const isLoading = titles === undefined;
+
+  return (
+    <Container className={className}>
+      {isLoading ? (
+        <Skeleton height={42} width={128} />
+      ) : (
+        titles?.map((title, i) => (
+          <BubbleButton
+            key={`btn-${title}`}
+            onClick={() => onClick(i)}
+            type="button"
+            highlighted={activeIndex === i}
+            scale={0.9}
+          >
+            {title}
+          </BubbleButton>
+        ))
+      )}
+    </Container>
+  );
+};

--- a/src/components/core/Toggle.tsx
+++ b/src/components/core/Toggle.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
   border-radius: 1.5rem;
   background: #eee;
 
-  button:nth-last-child(1) {
+  button:not(:first-child) {
     margin-left: -0.5rem;
   }
 `;

--- a/src/components/pages/PageHeader.tsx
+++ b/src/components/pages/PageHeader.tsx
@@ -70,7 +70,6 @@ const ChildrenRow = styled.div`
   margin-top: 1rem;
 
   @media (min-width: ${({ theme }) => theme.viewportWidth.s}) {
-    align-items: flex-start;
     flex-direction: row;
   }
 `;

--- a/src/components/pages/Save/ActiveSaveVersionProvider.tsx
+++ b/src/components/pages/Save/ActiveSaveVersionProvider.tsx
@@ -1,16 +1,115 @@
-import { createStateContext } from 'react-use';
-import { SaveVersion } from './v1/SaveProvider';
+import React, {
+  createContext,
+  FC,
+  Reducer,
+  useCallback,
+  useContext,
+  useMemo,
+  useReducer,
+} from 'react';
 
-export const SAVE_VERSIONS: SaveVersion[] = [
-  { version: 1 },
-  { version: 2, isCurrent: true },
-];
+export enum SaveVersion {
+  V1 = 1,
+  V2 = 2,
+}
 
-export const CURRENT_SAVE_VERSION = SAVE_VERSIONS.find(
-  v => v.isCurrent,
-) as SaveVersion;
+const { V1 } = SaveVersion;
 
-export const [
-  useActiveSaveVersion,
-  ActiveSaveVersionProvider,
-] = createStateContext(CURRENT_SAVE_VERSION);
+// Fallback to V1.
+export const DEFAULT_SAVE_VERSION = V1;
+export const SAVE_VERSIONS: SaveVersion[] = [V1];
+
+enum Actions {
+  SetActiveVersion,
+  SetVersions,
+}
+
+interface State {
+  versions: SaveVersion[];
+  activeVersion: SaveVersion | undefined;
+}
+
+interface Dispatch {
+  setActiveVersion(version: SaveVersion): void;
+  setVersions(versions: SaveVersion[]): void;
+}
+
+type Action =
+  | { type: Actions.SetActiveVersion; payload: SaveVersion }
+  | { type: Actions.SetVersions; payload: SaveVersion[] };
+
+const initialState: State = {
+  versions: SAVE_VERSIONS,
+  activeVersion: undefined,
+};
+
+const reducer: Reducer<State, Action> = (state, action) => {
+  switch (action.type) {
+    case Actions.SetActiveVersion:
+      return {
+        ...state,
+        activeVersion: action.payload,
+      };
+    case Actions.SetVersions:
+      return {
+        versions: action.payload,
+        activeVersion: action.payload[0],
+      };
+    default:
+      return state;
+  }
+};
+
+const stateCtx = createContext<State>(initialState);
+const dispatchCtx = createContext<Dispatch>({} as Dispatch);
+
+export const ActiveSaveVersionProvider: FC = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setActiveVersion = useCallback<Dispatch['setActiveVersion']>(
+    version => {
+      dispatch({
+        type: Actions.SetActiveVersion,
+        payload: version,
+      });
+    },
+    [dispatch],
+  );
+
+  const setVersions = useCallback<Dispatch['setVersions']>(
+    versions => {
+      dispatch({
+        type: Actions.SetVersions,
+        payload: versions,
+      });
+    },
+    [dispatch],
+  );
+
+  return (
+    <stateCtx.Provider value={state}>
+      <dispatchCtx.Provider
+        value={useMemo(() => ({ setActiveVersion, setVersions }), [
+          setActiveVersion,
+          setVersions,
+        ])}
+      >
+        {children}
+      </dispatchCtx.Provider>
+    </stateCtx.Provider>
+  );
+};
+
+export const useActiveSaveVersionState = (): State => useContext(stateCtx);
+
+export const useActiveSaveVersionDispatch = (): Dispatch =>
+  useContext(dispatchCtx);
+
+export const useSetActiveVersion = (): Dispatch['setActiveVersion'] =>
+  useContext(dispatchCtx).setActiveVersion;
+
+export const useSetSaveVersions = (): Dispatch['setVersions'] =>
+  useContext(dispatchCtx).setVersions;
+
+export const useActiveSaveVersion = (): number | undefined =>
+  useContext(stateCtx).activeVersion;

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -8,8 +8,14 @@ import { CountUp } from '../../core/CountUp';
 import { MUSDIconTransparent } from '../../icons/TokenIcon';
 import { AnalyticsLink } from '../Analytics/AnalyticsLink';
 import { ReactComponent as WarningBadge } from '../../icons/badges/warning.svg';
-import { useActiveSaveVersion } from './ActiveSaveVersionProvider';
+import {
+  DEFAULT_SAVE_VERSION,
+  SaveVersion,
+  useActiveSaveVersionState,
+} from './ActiveSaveVersionProvider';
 import { SaveMigration } from './SaveMigration';
+
+const { V1 } = SaveVersion;
 
 const CreditBalance = styled.div`
   display: flex;
@@ -76,37 +82,39 @@ const StyledWarningBadge = styled(WarningBadge)`
 `;
 
 export const SaveInfo: FC = () => {
-  const [activeVersion] = useActiveSaveVersion();
+  const { versions, activeVersion } = useActiveSaveVersionState();
   const massetName = useSelectedMasset();
   const massetState = useSelectedMassetState();
 
+  const isV1Deprecated = versions.length > 1;
+  const isV1ActiveAndCurrent = isV1Deprecated && activeVersion === V1;
+
   const savingsBalance =
-    massetState?.savingsContracts[`v${activeVersion.version}` as 'v1' | 'v2']
-      ?.savingsBalance;
+    massetState?.savingsContracts[
+      `v${activeVersion ?? DEFAULT_SAVE_VERSION}` as 'v1' | 'v2'
+    ]?.savingsBalance;
 
   return (
-    <>
-      <BalanceInfoRow>
-        <H3>
-          Your <b>{massetName}</b> savings balance
-        </H3>
-        <CreditBalance>
-          <MUSDIconTransparent />
-          <CountUp end={savingsBalance?.balance?.simple || 0} decimals={7} />
-          {!activeVersion.isCurrent && <StyledWarningBadge />}
-        </CreditBalance>
-        {activeVersion.isCurrent ? (
-          <AnalyticsLink section="save" />
-        ) : (
-          <>
-            <WarningMsg>
-              Migrate your <b>{massetName}</b> to continue earning interest on
-              your balance.
-            </WarningMsg>
-            <SaveMigration />
-          </>
-        )}
-      </BalanceInfoRow>
-    </>
+    <BalanceInfoRow>
+      <H3>
+        Your <b>{massetName}</b> savings balance
+      </H3>
+      <CreditBalance>
+        <MUSDIconTransparent />
+        <CountUp end={savingsBalance?.balance?.simple || 0} decimals={7} />
+        {isV1ActiveAndCurrent && <StyledWarningBadge />}
+      </CreditBalance>
+      {isV1ActiveAndCurrent ? (
+        <>
+          <WarningMsg>
+            Migrate your <b>{massetName}</b> to continue earning interest on
+            your balance.
+          </WarningMsg>
+          <SaveMigration />
+        </>
+      ) : (
+        <AnalyticsLink section="save" />
+      )}
+    </BalanceInfoRow>
   );
 };

--- a/src/components/pages/Save/ToggleSave.tsx
+++ b/src/components/pages/Save/ToggleSave.tsx
@@ -1,50 +1,67 @@
-import React, { FC, useCallback, useEffect, useRef } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 
 import {
-  CURRENT_SAVE_VERSION,
-  SAVE_VERSIONS,
-  useActiveSaveVersion,
+  SaveVersion,
+  useActiveSaveVersionState,
+  useSetActiveVersion,
+  useSetSaveVersions,
 } from './ActiveSaveVersionProvider';
 import { useV1SavingsBalance } from '../../../context/DataProvider/DataProvider';
 import { Toggle } from '../../core/Toggle';
+import { useSelectedSaveV2Contract } from '../../../web3/hooks';
+
+const { V1, V2 } = SaveVersion;
+
+const VERSION_TITLES = new Map<SaveVersion, string>([
+  [V1, 'V1'],
+  [V2, 'V2'],
+]);
 
 export const ToggleSave: FC = () => {
-  const setSaveVersion = useRef(false);
-  const [activeVersion, setActiveVersion] = useActiveSaveVersion();
+  const { activeVersion, versions } = useActiveSaveVersionState();
+  const setActiveVersion = useSetActiveVersion();
+  const setSaveVersions = useSetSaveVersions();
   const v1Balance = useV1SavingsBalance();
+  const v2Contract = useSelectedSaveV2Contract();
 
-  // const v1Contract = useSelectedSaveV1Contract();
-  // const v2Contract = useSelectedSaveV2Contract();
-
+  // Set the save version to v1 (once only) if there is a v1 balance
   useEffect(() => {
-    // Set the save version to v1 (once only) if there is a v1 balance
-    if (!setSaveVersion.current && v1Balance?.balance) {
+    if (activeVersion !== undefined) {
+      return;
+    }
+
+    // v2 contract not present, set versions to [v1]
+    if (v2Contract === undefined) {
+      setSaveVersions([V1]);
+    }
+
+    // v2 contract present, set to [v2, v1]
+    setSaveVersions([V2, V1]);
+
+    // priortise ordering based on balance
+    if (v1Balance?.balance) {
       if (v1Balance.balance.exact.gt(0)) {
-        setActiveVersion(SAVE_VERSIONS[0]);
-        setSaveVersion.current = true;
+        setSaveVersions([V2, V1]);
+        setActiveVersion(V1);
       }
     }
-  }, [setActiveVersion, v1Balance]);
+  }, [activeVersion, setActiveVersion, setSaveVersions, v1Balance, v2Contract]);
 
   const handleOnClick = useCallback(
-    (i: number) =>
-      setActiveVersion(i === 0 ? CURRENT_SAVE_VERSION : SAVE_VERSIONS[0]),
-    [setActiveVersion],
+    (i: number) => setActiveVersion(i === 0 ? versions[0] : versions[1]),
+    [setActiveVersion, versions],
   );
 
-  const titles = ((): string[] | undefined => {
-    // if (v2Contract === undefined && v1Contract === undefined) return undefined;
-    // if (v2Contract !== undefined) {
-    //   return ['V2', 'V1 (Deprecated)'];
-    // }
-    return ['V1'];
-  })();
+  const titles = versions.map(
+    (version, i) =>
+      `${VERSION_TITLES.get(version) ?? ''} ${i > 0 ? ` (Deprecated)` : ''}`,
+  );
 
   return (
     <Toggle
       onClick={handleOnClick}
       titles={titles}
-      activeIndex={activeVersion.isCurrent ? 0 : 1}
+      activeIndex={versions.length - (activeVersion ?? 0)}
     />
   );
 };

--- a/src/components/pages/Save/ToggleSave.tsx
+++ b/src/components/pages/Save/ToggleSave.tsx
@@ -33,6 +33,7 @@ export const ToggleSave: FC = () => {
     // v2 contract not present, set versions to [v1]
     if (v2Contract === undefined) {
       setSaveVersions([V1]);
+      return;
     }
 
     // v2 contract present, set to [v2, v1]
@@ -41,7 +42,6 @@ export const ToggleSave: FC = () => {
     // priortise ordering based on balance
     if (v1Balance?.balance) {
       if (v1Balance.balance.exact.gt(0)) {
-        setSaveVersions([V2, V1]);
         setActiveVersion(V1);
       }
     }

--- a/src/components/pages/Save/ToggleSave.tsx
+++ b/src/components/pages/Save/ToggleSave.tsx
@@ -1,33 +1,20 @@
-import React, { FC, useEffect, useRef } from 'react';
-import styled from 'styled-components';
+import React, { FC, useCallback, useEffect, useRef } from 'react';
 
-import { BubbleButton } from '../../core/Button';
 import {
   CURRENT_SAVE_VERSION,
   SAVE_VERSIONS,
   useActiveSaveVersion,
 } from './ActiveSaveVersionProvider';
 import { useV1SavingsBalance } from '../../../context/DataProvider/DataProvider';
+import { Toggle } from '../../core/Toggle';
 
-interface Props {
-  className?: string;
-  disabled?: boolean;
-}
-
-const Container = styled.div`
-  padding: 0;
-  border-radius: 1.5rem;
-  background: #eee;
-
-  button:nth-last-child(1) {
-    margin-left: -0.5rem;
-  }
-`;
-
-export const ToggleSave: FC<Props> = ({ className }) => {
+export const ToggleSave: FC = () => {
   const setSaveVersion = useRef(false);
   const [activeVersion, setActiveVersion] = useActiveSaveVersion();
   const v1Balance = useV1SavingsBalance();
+
+  // const v1Contract = useSelectedSaveV1Contract();
+  // const v2Contract = useSelectedSaveV2Contract();
 
   useEffect(() => {
     // Set the save version to v1 (once only) if there is a v1 balance
@@ -39,28 +26,25 @@ export const ToggleSave: FC<Props> = ({ className }) => {
     }
   }, [setActiveVersion, v1Balance]);
 
+  const handleOnClick = useCallback(
+    (i: number) =>
+      setActiveVersion(i === 0 ? CURRENT_SAVE_VERSION : SAVE_VERSIONS[0]),
+    [setActiveVersion],
+  );
+
+  const titles = ((): string[] | undefined => {
+    // if (v2Contract === undefined && v1Contract === undefined) return undefined;
+    // if (v2Contract !== undefined) {
+    //   return ['V2', 'V1 (Deprecated)'];
+    // }
+    return ['V1'];
+  })();
+
   return (
-    <Container className={className}>
-      <BubbleButton
-        onClick={() => {
-          setActiveVersion(CURRENT_SAVE_VERSION);
-        }}
-        type="button"
-        highlighted={activeVersion.isCurrent}
-        scale={0.9}
-      >
-        V2
-      </BubbleButton>
-      <BubbleButton
-        onClick={() => {
-          setActiveVersion(SAVE_VERSIONS[0]);
-        }}
-        type="button"
-        highlighted={!activeVersion.isCurrent}
-        scale={0.9}
-      >
-        V1 (Deprecated)
-      </BubbleButton>
-    </Container>
+    <Toggle
+      onClick={handleOnClick}
+      titles={titles}
+      activeIndex={activeVersion.isCurrent ? 0 : 1}
+    />
   );
 };

--- a/src/components/pages/Save/index.tsx
+++ b/src/components/pages/Save/index.tsx
@@ -8,12 +8,15 @@ import { FormProvider } from '../../forms/TransactionForm/FormProvider';
 import { PageHeader } from '../PageHeader';
 import {
   ActiveSaveVersionProvider,
-  useActiveSaveVersion,
+  SaveVersion,
+  useActiveSaveVersionState,
 } from './ActiveSaveVersionProvider';
 import { SaveProvider } from './v1/SaveProvider';
 import { SaveInfo } from './SaveInfo';
 import { SaveForm } from './v1/SaveForm';
 import { ToggleSave } from './ToggleSave';
+
+const { V1, V2 } = SaveVersion;
 
 const APYStats = styled.div`
   display: flex;
@@ -61,16 +64,18 @@ const InfoMsg = styled.div`
   }
 `;
 
-export const Save: FC = () => {
-  const [activeVersion] = useActiveSaveVersion();
+const SaveContent: FC = () => {
+  const { versions, activeVersion } = useActiveSaveVersionState();
   const apyForPastWeek = useAverageApyForPastWeek();
 
+  const isV1Deprecated = versions.length > 1;
+  const showForm =
+    (isV1Deprecated && activeVersion === V2) ||
+    (!isV1Deprecated && activeVersion === V1);
+
   return (
-    <ActiveSaveVersionProvider>
-      <PageHeader
-        title={`Save V${activeVersion.version}`}
-        subtitle="Earn interest on your deposited mUSD"
-      >
+    <>
+      <PageHeader title="Save" subtitle="Earn interest on your deposited mUSD">
         <ToggleContainer>
           <ToggleSave />
         </ToggleContainer>
@@ -95,13 +100,21 @@ export const Save: FC = () => {
         </APYStats>
       </PageHeader>
       <SaveInfo />
-      {activeVersion.isCurrent && (
+      {showForm && (
         <SaveProvider>
           <FormProvider formId="save">
             <SaveForm />
           </FormProvider>
         </SaveProvider>
       )}
+    </>
+  );
+};
+
+export const Save: FC = () => {
+  return (
+    <ActiveSaveVersionProvider>
+      <SaveContent />
     </ActiveSaveVersionProvider>
   );
 };

--- a/src/components/pages/Save/v1/SaveForm.tsx
+++ b/src/components/pages/Save/v1/SaveForm.tsx
@@ -27,12 +27,12 @@ export const SaveForm: FC = () => {
   const setFormManifest = useSetFormManifest();
   const savingsContractV1 = useSelectedSaveV1Contract();
   const savingsContractV2 = useSelectedSaveV2Contract();
-  const [activeVersion] = useActiveSaveVersion();
+  const activeVersion = useActiveSaveVersion();
   const walletAddress = useWalletAddress();
 
   // Set the form manifest
   useEffect(() => {
-    if (activeVersion.version === 2 && savingsContractV2) {
+    if (activeVersion === 2 && savingsContractV2) {
       if (
         transactionType === TransactionType.Deposit &&
         amount &&
@@ -104,7 +104,7 @@ export const SaveForm: FC = () => {
     transactionType,
     massetSymbol,
     walletAddress,
-    activeVersion.version,
+    activeVersion,
   ]);
 
   return (

--- a/src/components/pages/Save/v1/SaveProvider.tsx
+++ b/src/components/pages/Save/v1/SaveProvider.tsx
@@ -12,11 +12,6 @@ import { useSelectedMassetState } from '../../../../context/DataProvider/DataPro
 import { reducer } from './reducer';
 import { Actions, Dispatch, State, TransactionType } from './types';
 
-export interface SaveVersion {
-  version: number;
-  isCurrent?: boolean;
-}
-
 const initialState: State = {
   formValue: null,
   initialized: false,

--- a/src/context/SelectedMassetProvider.ts
+++ b/src/context/SelectedMassetProvider.ts
@@ -5,7 +5,7 @@ import { MassetName } from '../types';
 
 const [useSelectedMassetCtx, SelectedMassetProvider] = createStateContext<
   MassetName
->('mBTC');
+>('mUSD');
 
 export const useSelectedMasset = (): MassetName => useSelectedMassetCtx()[0];
 

--- a/src/web3/hooks.ts
+++ b/src/web3/hooks.ts
@@ -7,6 +7,7 @@ import { useSigner } from '../context/OnboardProvider';
 import {
   useSelectedMassetState,
   useSelectedSaveV1Address,
+  useSelectedSaveV2Address,
 } from '../context/DataProvider/DataProvider';
 import { Erc20DetailedFactory } from '../typechain/Erc20DetailedFactory';
 import { MassetFactory } from '../typechain/MassetFactory';
@@ -15,6 +16,7 @@ import { SavingsContract } from '../typechain/SavingsContract.d';
 import { Erc20Detailed } from '../typechain/Erc20Detailed.d';
 import { Masset } from '../typechain/Masset.d';
 import { truncateAddress } from './strings';
+import { useActiveSaveVersion } from '../components/pages/Save/ActiveSaveVersionProvider';
 
 interface BlockTime {
   timestamp: number;
@@ -133,12 +135,15 @@ export const timestampsForWeek = eachDayOfInterval({
   .concat(now);
 
 export const useAverageApyForPastWeek = (): number | undefined => {
-  // TODO support v1/v2
-  const savingsContractAddress = useSelectedSaveV1Address();
+  const activeVersion = useActiveSaveVersion();
+  const savingsV1ContractAddress = useSelectedSaveV1Address();
+  const savingsV2ContractAddress = useSelectedSaveV2Address();
+  
+  const currentContractAddress = activeVersion === 1 ? savingsV1ContractAddress : savingsV2ContractAddress;
 
   const blockTimes = useBlockTimesForDates(timestampsForWeek);
   const dailyApys = useDailyApysForBlockTimes(
-    savingsContractAddress,
+    currentContractAddress,
     blockTimes,
   );
   return useMemo(() => {


### PR DESCRIPTION
Message component to alert the user to Save V2. Displays globally + can be toggled / messaged changed.

# Screenshots
|  V1, V2 |  
| --- | 
| <img width="988" alt="Screenshot 2020-12-10 at 15 12 21" src="https://user-images.githubusercontent.com/19643324/101783278-5a878d00-3afa-11eb-86d4-af9f87c52a5d.png"> |

|  V1, no V2 |  
| --- | 
| <img width="991" alt="Screenshot 2020-12-10 at 15 11 16" src="https://user-images.githubusercontent.com/19643324/101783284-5bb8ba00-3afa-11eb-8c1b-cf88a5401587.png"> |