### PR TITLE
Adjust analytics for save-v2

### DIFF
--- a/src/components/pages/Analytics/index.tsx
+++ b/src/components/pages/Analytics/index.tsx
@@ -36,9 +36,6 @@ const TotalSupply: FC = () => {
 const TotalSavings: FC = () => {
   const savingsContractState = useSelectedSavingsContractState();
   const totalSavings = savingsContractState?.totalSavings;
-  // // eslint-disable-next-line no-console
-  // console.log('totalSavings', totalSavings);
-  // const totalSavings = massetState?.savingsContracts?.v1?.totalSavings;
   return (
     <div>
       <H3 borderTop>Total savings</H3>
@@ -84,6 +81,10 @@ const ToggleContainer = styled.div<{ borderTop?: boolean }>`
   align-items: center;
   justify-content: space-between;
   ${({ theme, borderTop }) => (borderTop ? theme.mixins.borderTop : '')}
+  > :first-child {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
 `;
 
 export const Analytics: FC = () => {

--- a/src/components/pages/Analytics/index.tsx
+++ b/src/components/pages/Analytics/index.tsx
@@ -11,6 +11,8 @@ import { AggregateChart } from '../../stats/AggregateChart';
 import { PageHeader } from '../PageHeader';
 import { Size } from '../../../theme';
 import { DailyApys } from '../../stats/DailyApys';
+import { ToggleSave } from '../Save/ToggleSave';
+import { useSelectedSavingsContractState } from '../../../context/SelectedSaveVersionProvider';
 
 const Section = styled.section`
   padding-bottom: 32px;
@@ -32,8 +34,11 @@ const TotalSupply: FC = () => {
 };
 
 const TotalSavings: FC = () => {
-  const massetState = useSelectedMassetState();
-  const totalSavings = massetState?.savingsContracts?.v1?.totalSavings;
+  const savingsContractState = useSelectedSavingsContractState();
+  const totalSavings = savingsContractState?.totalSavings;
+  // // eslint-disable-next-line no-console
+  // console.log('totalSavings', totalSavings);
+  // const totalSavings = massetState?.savingsContracts?.v1?.totalSavings;
   return (
     <div>
       <H3 borderTop>Total savings</H3>
@@ -74,6 +79,13 @@ const ThirdPartySources = styled.ul`
   }
 `;
 
+const ToggleContainer = styled.div<{ borderTop?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  ${({ theme, borderTop }) => (borderTop ? theme.mixins.borderTop : '')}
+`;
+
 export const Analytics: FC = () => {
   useLayoutEffect(() => {
     window.scrollTo({ top: 0 });
@@ -86,7 +98,10 @@ export const Analytics: FC = () => {
         subtitle="Explore activity across mStable"
       />
       <Section id="save">
-        <H2 borderTop>SAVE</H2>
+        <ToggleContainer borderTop>
+          <H2>SAVE</H2>
+          <ToggleSave />
+        </ToggleContainer>
         <DailyApys />
       </Section>
       <Section id="volumes">

--- a/src/components/pages/Analytics/index.tsx
+++ b/src/components/pages/Analytics/index.tsx
@@ -80,6 +80,8 @@ const ToggleContainer = styled.div<{ borderTop?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   ${({ theme, borderTop }) => (borderTop ? theme.mixins.borderTop : '')}
   > :first-child {
     padding-bottom: 0;

--- a/src/components/stats/AggregateChart.tsx
+++ b/src/components/stats/AggregateChart.tsx
@@ -81,6 +81,7 @@ const useAggregateMetrics = (): {
         totalSupply {
           simple
         }
+        #first deposited version of save-v2
         savingsContracts(where: {version: $version, id_not: "0x478e379d5f3e2f949a94f1ccfb7217fb35916615"}) {
           totalSavings {
             simple

--- a/src/components/stats/DailyApys.tsx
+++ b/src/components/stats/DailyApys.tsx
@@ -9,8 +9,6 @@ import {
 } from 'recharts';
 import Skeleton from 'react-loading-skeleton';
 import { format } from 'date-fns';
-
-import { useSaveV1Address } from '../../context/DataProvider/DataProvider';
 import {
   useDailyApysForBlockTimes,
   useBlockTimesForDates,
@@ -19,6 +17,7 @@ import { Color } from '../../theme';
 import { percentageFormat, periodFormatMapping } from './utils';
 import { DateRange, Metrics, useDateFilter, useMetrics } from './Metrics';
 import { RechartsContainer } from './RechartsContainer';
+import { useSelectedSavingsContractState } from '../../context/SelectedSaveVersionProvider';
 
 enum MetricTypes {
   DailyApy = 'DailyApy',
@@ -47,13 +46,11 @@ const formatApy = (percentage: number): string =>
 const DailyApysChart: FC = () => {
   const dateFilter = useDateFilter();
   const { DailyApy, UtilisationRate } = useMetrics<MetricTypes>();
-
   const blockTimes = useBlockTimesForDates(dateFilter.dates);
 
-  // TODO support v1/v2
-  const savingsContractAddress = useSaveV1Address();
+  const savingsContractState = useSelectedSavingsContractState();
   const dailyApys = useDailyApysForBlockTimes(
-    savingsContractAddress,
+    savingsContractState?.address,
     blockTimes,
   );
 

--- a/src/components/stats/VolumeChart.tsx
+++ b/src/components/stats/VolumeChart.tsx
@@ -196,14 +196,14 @@ const useVolumeMetrics = (): ({ timestamp: number } & Record<
             savingsContracts,
           } = values;
 
-          const collectiveDeposited = savingsContracts.reduce(
-            (prev, { cumulativeDeposited }) =>
-              prev + parseFloat(cumulativeDeposited.simple),
+          let collectiveDeposited = savingsContracts.reduce(
+            (_prev, { cumulativeDeposited }) =>
+              _prev + parseFloat(cumulativeDeposited.simple),
             0,
           );
-          const collectiveWithdrawn = savingsContracts.reduce(
-            (prev, { cumulativeWithdrawn }) =>
-              prev + parseFloat(cumulativeWithdrawn.simple),
+          let collectiveWithdrawn = savingsContracts.reduce(
+            (_prev, { cumulativeWithdrawn }) =>
+              _prev + parseFloat(cumulativeWithdrawn.simple),
             0,
           );
           let minted = parseFloat(cumulativeMinted.simple);
@@ -218,14 +218,16 @@ const useVolumeMetrics = (): ({ timestamp: number } & Record<
             // TODO too repetitive; shouldn't be doing this anyway;
             // the daily values should be on the subgraph
             minted -= parseFloat(prev.cumulativeMinted.simple);
-            // I commented these out, do we need them? :thinking:
-
-            // deposited -= parseFloat(
-            //   prev.savingsContracts[0].cumulativeDeposited.simple,
-            // );
-            // withdrawn -= parseFloat(
-            //   prev.savingsContracts[0].cumulativeWithdrawn.simple,
-            // );
+            collectiveDeposited -= prev.savingsContracts.reduce(
+              (_prev, { cumulativeDeposited }) =>
+                _prev + parseFloat(cumulativeDeposited.simple),
+              0,
+            );
+            collectiveWithdrawn -= prev.savingsContracts.reduce(
+              (_prev, { cumulativeWithdrawn }) =>
+                _prev + parseFloat(cumulativeWithdrawn.simple),
+              0,
+            );
             swapped -= parseFloat(prev.cumulativeSwapped.simple);
             redeemed -=
               parseFloat(prev.cumulativeRedeemed.simple) +


### PR DESCRIPTION

![img](https://user-images.githubusercontent.com/23094095/102095318-afd9dc00-3e23-11eb-98b6-970aee9cc5ca.png)


Changes:

- Added contract version switcher to the analytics page

- Adjusted volume query to take save v2 into the account and calculate cumulative deposit/withdraw from both save v1 and save v2

- Adjusted total savings  and daily apys query to take contract version into the account

