### PR TITLE
Support peripheral contracts

### DIFF
--- a/src/context/TokensProvider.tsx
+++ b/src/context/TokensProvider.tsx
@@ -14,6 +14,7 @@ import { AllTokensQueryResult } from '../graphql/protocol';
 import { Allowances, SubscribedToken } from '../types';
 import { BigDecimal } from '../web3/BigDecimal';
 import { CURVE_ADDRESSES } from './earn/CurveProvider';
+import { ADDRESSES } from '../web3/constants';
 
 interface State {
   tokens: {
@@ -502,9 +503,7 @@ export const useTokenSubscription = (
 };
 
 export const useMetaToken = (): SubscribedToken | undefined =>
-  useTokenSubscription(
-    (process.env.REACT_APP_MTA_ADDRESS as string).toLowerCase(),
-  );
+  useTokenSubscription(ADDRESSES.MTA.toLowerCase());
 
 export const useTokenAllowance = (
   address: string | undefined | null,

--- a/src/web3/constants.ts
+++ b/src/web3/constants.ts
@@ -17,6 +17,28 @@ export const NETWORK_NAMES = {
   1337: 'Local network',
 };
 
+interface Network {
+  [key: number]: object;
+}
+
+const ADDRESSES_BY_NETWORK: Network = Object.freeze({
+  1: {
+    MTA: '0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2',
+    SaveWrapper: 'TODO',
+  },
+  3: {
+    MTA: '0x273bc479e5c21caa15aa8538decbf310981d14c0',
+    SaveWrapper: '0xF078E3146160459fF7bb09D1D5e2D40238A7bCbe',
+  },
+  42: {
+    MTA: '0xcda64b5d3ca85800ab9f7409686985b59f2b9598',
+    SaveWrapper: 'TODO',
+  },
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const ADDRESSES = ADDRESSES_BY_NETWORK[CHAIN_ID];
+
 export const EMOJIS = {
   error: '❌',
   approve: '✔️',

--- a/src/web3/constants.ts
+++ b/src/web3/constants.ts
@@ -17,27 +17,41 @@ export const NETWORK_NAMES = {
   1337: 'Local network',
 };
 
-interface Network {
-  [key: number]: object;
+interface Addresses {
+  MTA: string;
+
+  mUSD: {
+    SaveWrapper: string;
+  };
+  mBTC?: {
+    SaveWrapper: string;
+  };
 }
 
-const ADDRESSES_BY_NETWORK: Network = Object.freeze({
+type AddressesByNetwork = Record<typeof CHAIN_ID, Addresses>;
+
+const ADDRESSES_BY_NETWORK: AddressesByNetwork = Object.freeze({
   1: {
     MTA: '0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2',
-    SaveWrapper: 'TODO',
+    mUSD: {
+      SaveWrapper: 'TODO',
+    },
   },
   3: {
     MTA: '0x273bc479e5c21caa15aa8538decbf310981d14c0',
-    SaveWrapper: '0xF078E3146160459fF7bb09D1D5e2D40238A7bCbe',
+    mUSD: {
+      SaveWrapper: '0xF078E3146160459fF7bb09D1D5e2D40238A7bCbe',
+    },
   },
   42: {
     MTA: '0xcda64b5d3ca85800ab9f7409686985b59f2b9598',
-    SaveWrapper: 'TODO',
+    mUSD: {
+      SaveWrapper: 'TODO',
+    },
   },
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ADDRESSES = ADDRESSES_BY_NETWORK[CHAIN_ID];
+export const ADDRESSES: Addresses = ADDRESSES_BY_NETWORK[CHAIN_ID];
 
 export const EMOJIS = {
   error: '❌',


### PR DESCRIPTION
Changes:

- Added constant `ADDRESSES_BY_NETWORK` with currently existing values for `MTA` and `SaveWrapper`, some values will have to be filled in as they get created
- Added constant `ADDRESSES` which selects addresses from a currently active chain