### PR TITLE
Boost calculation

### DIFF
--- a/.env.example.ropsten
+++ b/.env.example.ropsten
@@ -1,7 +1,7 @@
 REACT_APP_VERSION=$npm_package_version
-REACT_APP_GRAPHQL_ENDPOINT_LEGACY=https://api.thegraph.com/subgraphs/name/mstable/mstable-legacy-ropsten
+REACT_APP_GRAPHQL_ENDPOINT_LEGACY=https://api.thegraph.com/subgraphs/name/mstable/mstable-protocol-legacy
 REACT_APP_GRAPHQL_ENDPOINT_PROTOCOL=https://api.thegraph.com/subgraphs/name/mstable/mstable-protocol-ropsten
-REACT_APP_GRAPHQL_ENDPOINT_ECOSYSTEM=https://api.thegraph.com/subgraphs/name/mstable/mstable-ecosystem-ropsten
+REACT_APP_GRAPHQL_ENDPOINT_ECOSYSTEM=https://api.thegraph.com/subgraphs/name/mstable/mstable-ecosystem
 
 # This is mainnet: no Balancer Ropsten subgraph is actively maintained at the moment
 REACT_APP_GRAPHQL_ENDPOINT_BALANCER=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer

--- a/src/components/core/CountUp.tsx
+++ b/src/components/core/CountUp.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { ComponentProps, FC, useEffect, useRef } from 'react';
 import { useCountUp, CountUpProps } from 'react-countup';
 import styled from 'styled-components';
 import { useFirstMountState } from 'react-use/lib/useFirstMountState';
@@ -41,7 +41,7 @@ export const CountUp: FC<Props> = ({
   separator = ',',
   duration = DEFAULT_DURATION,
 }) => {
-    // eslint-disable-next-line no-restricted-globals
+  // eslint-disable-next-line no-restricted-globals
   const isValid = typeof end === 'number' && !isNaN(end);
   const prevEnd = useRef(isValid ? end : 0);
   const isIdle = useIsIdle();
@@ -81,5 +81,25 @@ export const CountUp: FC<Props> = ({
       <Number>{isValid ? countUp : '–'}</Number>
       {suffix ? <PrefixOrSuffix>{suffix}</PrefixOrSuffix> : null}
     </Container>
+  );
+};
+
+export const DifferentialCountup: FC<ComponentProps<typeof CountUp> & {
+  prev?: number;
+}> = ({ prev, end, ...props }) => {
+  return (
+    <CountUp
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      end={end}
+      highlight
+      highlightColor={
+        typeof prev !== 'number' || typeof end !== 'number' || end === prev
+          ? Color.blue
+          : end > prev
+          ? Color.green
+          : Color.red
+      }
+    />
   );
 };

--- a/src/components/forms/SubscribedTokenInput.tsx
+++ b/src/components/forms/SubscribedTokenInput.tsx
@@ -95,10 +95,6 @@ const Selected = styled.div`
   > div:hover {
     background: none;
   }
-
-  ${Balance} {
-    display: none;
-  }
 `;
 
 const DownArrow = styled.div`

--- a/src/components/icons/TokenIcon.tsx
+++ b/src/components/icons/TokenIcon.tsx
@@ -18,6 +18,7 @@ import Uniswap, { ReactComponent as UniswapSvg } from './tokens/Uniswap.svg';
 import Balancer, { ReactComponent as BalancerSvg } from './tokens/Balancer.svg';
 import ETH, { ReactComponent as EtherSvg } from './tokens/Ether.svg';
 import IMUSD, { ReactComponent as ImusdSvg } from './tokens/imUSD.svg';
+import VMTA, { ReactComponent as VmtaSvg } from './tokens/vMTA.svg';
 
 interface Props {
   className?: string;
@@ -48,6 +49,7 @@ export const TOKEN_ICONS: Record<string, string> = {
   'MK-MTA': MTA,
   'MK-BAL': Balancer,
   IMUSD,
+  VMTA,
 };
 
 const SVG_ICONS: Record<string, SvgComponent> = {
@@ -70,6 +72,7 @@ const SVG_ICONS: Record<string, SvgComponent> = {
   'MK-MTA': MtaSvg as SvgComponent,
   'MK-BAL': BalancerSvg as SvgComponent,
   IMUSD: ImusdSvg as SvgComponent,
+  VMTA: VmtaSvg as SvgComponent,
 };
 
 const Image = styled.img`

--- a/src/components/pages/Save/v2/AssetTokenInput.tsx
+++ b/src/components/pages/Save/v2/AssetTokenInput.tsx
@@ -139,7 +139,6 @@ const Container = styled.div<{
 }>`
   background: ${({ theme, overweight }) =>
     overweight ? theme.color.blackTransparenter : theme.color.white};
-  margin-bottom: 8px;
 `;
 
 export const AssetTokenInput: FC<Props> = ({

--- a/src/components/pages/Save/v2/index.tsx
+++ b/src/components/pages/Save/v2/index.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 
-import Skeleton from 'react-loading-skeleton';
-import { SaveMode } from './types';
 import { useSaveState, useSaveDispatch, SaveProvider } from './SaveProvider';
 import { TabsContainer, TabBtn } from '../../../core/Tabs';
 import { Deposit } from './Deposit';
 import { Withdraw } from './Withdraw';
+import { SaveMode } from './types';
 
 const MODE_TYPES = {
   [SaveMode.Deposit]: {
@@ -45,15 +44,7 @@ const SaveForm: FC = () => {
         <TabButton tabMode={SaveMode.Deposit} />
         <TabButton tabMode={SaveMode.Withdraw} />
       </TabsContainer>
-      <div>
-        {mode === SaveMode.Deposit ? (
-          <Deposit />
-        ) : mode === SaveMode.Withdraw ? (
-          <Withdraw />
-        ) : (
-          <Skeleton />
-        )}
-      </div>
+      <div>{mode === SaveMode.Deposit ? <Deposit /> : <Withdraw />}</div>
     </Container>
   );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const CHAIN_ID = parseInt(process.env.REACT_APP_CHAIN_ID as string, 10);
 
 interface Addresses {
   MTA: string;
+  vMTA: string;
 
   mUSD: {
     SaveWrapper: string;
@@ -30,18 +31,21 @@ type AddressesByNetwork = Record<typeof CHAIN_ID, Addresses>;
 const ADDRESSES_BY_NETWORK: AddressesByNetwork = Object.freeze({
   1: {
     MTA: '0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2',
+    vMTA: '0xae8bc96da4f9a9613c323478be181fdb2aa0e1bf',
     mUSD: {
       SaveWrapper: 'TODO',
     },
   },
   3: {
     MTA: '0x273bc479e5c21caa15aa8538decbf310981d14c0',
+    vMTA: '0x77f9bf80e0947408f64faa07fd150920e6b52015',
     mUSD: {
-      SaveWrapper: '0xF078E3146160459fF7bb09D1D5e2D40238A7bCbe',
+      SaveWrapper: '0xf078e3146160459ff7bb09d1d5e2d40238a7bcbe',
     },
   },
   42: {
     MTA: '0xcda64b5d3ca85800ab9f7409686985b59f2b9598',
+    vMTA: 'TODO',
     mUSD: {
       SaveWrapper: 'TODO',
     },

--- a/src/hooks/useBigDecimalInput.ts
+++ b/src/hooks/useBigDecimalInput.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+
+import { BigDecimal } from '../web3/BigDecimal';
+
+/**
+ * This hook is designed to be used in tandem with amount inputs.
+ *
+ * @param initialValue Initial BigDecimal value (optional)
+ * @param decimals Decimals to create BigNumber values with
+ * @returns [value, formValue, onChange]
+ */
+export const useBigDecimalInput = (
+  initialValue?: BigDecimal | string,
+  decimals = 18,
+): [
+  BigDecimal | undefined,
+  string | null,
+  (formValue: string | null) => void,
+] => {
+  const [value, setValue] = useState<BigDecimal | undefined>(
+    initialValue instanceof BigDecimal
+      ? initialValue
+      : BigDecimal.maybeParse(initialValue, decimals),
+  );
+
+  const [formValue, setFormValue] = useState<string | null>(
+    value?.format(2, false) ?? null,
+  );
+
+  const onChange = useCallback(
+    (_formValue: string | null) => {
+      setFormValue(_formValue);
+      setValue(BigDecimal.maybeParse(_formValue, decimals));
+    },
+    [decimals],
+  );
+
+  return [value, formValue, onChange];
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
-    "noFallthroughCasesInSwitch": true,
-    "jsx": "react-jsx"
+    "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION

<img width="610" alt="Screenshot 2021-01-07 at 01 59 45" src="https://user-images.githubusercontent.com/5450382/103837971-2ddc7c00-508c-11eb-98a6-5c2c2d55ff02.png">

<img width="551" alt="Screenshot 2021-01-07 at 02 00 10" src="https://user-images.githubusercontent.com/5450382/103837981-33d25d00-508c-11eb-88f5-1678c9846757.png">

<img width="541" alt="Screenshot 2021-01-07 at 02 00 19" src="https://user-images.githubusercontent.com/5450382/103837964-2a48f500-508c-11eb-81d1-e0a9cf2bc48a.png">



**Savings boost widget**

- Read balances and use to show actual boost
- Support savings boost calculation with amount inputs
- Support 'preview max' calculation
- Adjust style of widget
- Remove interval/placeholder
- Add token icons
- Add tooltips


**Misc**

- Remove unnecessary compilerOption
- Fix env vars for Ropsten
- Add `useBigDecimalInput` hook
- Add vMTA address constant
- Add vMTA token icon
- Show balance of selected token in asset amount input
- Add `DifferentialCountup`
