### PR TITLE
Fix earn APYs not showing

### DIFF
--- a/src/components/pages/Earn/PoolsOverview.tsx
+++ b/src/components/pages/Earn/PoolsOverview.tsx
@@ -173,7 +173,7 @@ export const PoolsOverview: FC<{}> = () => {
                   if (expired) {
                     return <>N/A</>;
                   }
-                  return item.apy.value?.exact.gt(0) ? (
+                  return item.apy.value?.exact ? (
                     <div>
                       <MtaApyAmount
                         amount={item.apy.value}

--- a/src/context/earn/transformEarnData.ts
+++ b/src/context/earn/transformEarnData.ts
@@ -89,9 +89,7 @@ const getStakingRewardsContractsMap = (
 
         const stakingToken = {
           ...data.stakingToken,
-          totalSupply: BigDecimal.fromMetric(
-            data.stakingToken.totalSupply,
-          ),
+          totalSupply: BigDecimal.fromMetric(data.stakingToken.totalSupply),
           price: tokenPrices[data.stakingToken.address],
         };
 
@@ -258,11 +256,12 @@ const getStakingRewardsContractsMap = (
           const rewardsTokenPrice = rewardsToken?.price?.simple;
 
           // Prerequisites
-          const hasPrerequisites =
+          const hasPrerequisites = !!(
             block24hAgo &&
             result.rewardPerTokenStored24hAgo &&
             stakingTokenPrice &&
-            rewardsTokenPrice;
+            rewardsTokenPrice
+          );
 
           if (!hasPrerequisites) {
             return undefined;
@@ -286,16 +285,28 @@ const getStakingRewardsContractsMap = (
           // percentage = gains / stakingTokenPrice
           const percentage = gains / stakingTokenPrice;
 
+          console.log({
+            rewardsTokenPrice,
+            deltaR,
+            deltaT,
+            gains,
+            percentage,
+            apy: percentage * ((365 * 24 * 60 * 60) / deltaT),
+          });
+
           // apy = percentage * (seconds in year / deltaT)
           return percentage * ((365 * 24 * 60 * 60) / deltaT);
         })();
 
+        const value =
+          typeof apyValue === 'number'
+            ? new BigDecimal(apyValue.toString(), 18)
+            : undefined;
+
         const withApy = {
           ...result,
           apy: {
-            value: apyValue
-              ? new BigDecimal(apyValue.toString(), 18)
-              : undefined,
+            value,
             waitingForData: !rewardPerTokenStored24hAgo,
             yieldApy:
               isCurve && curveJsonData?.yieldApy?.toString

--- a/src/context/earn/useSyncedEarnData.ts
+++ b/src/context/earn/useSyncedEarnData.ts
@@ -31,7 +31,7 @@ interface CoingeckoPrices {
   [address: string]: { usd: number };
 }
 
-const START = Math.floor(Date.now() / 1e3) - 16 * 60 * 60;
+const START = Math.floor(Date.now() / 1e3) - 24 * 60 * 60;
 
 const useBlockTimestamp24hAgo = (): BlockTimestamp | undefined => {
   const query = useBlockTimestampQuery({


### PR DESCRIPTION
- Address an issue in which earn APYs do not show if the reward rate per token stored has not increased during a given time; ensure a period of 24h is used to compare rates
- Instead of showing a loading indicator for zero-value APYs, show '-'