### PR TITLE
Fix `GetStarted` slider for wallet connection

### DIFF
--- a/src/components/pages/Home/index.tsx
+++ b/src/components/pages/Home/index.tsx
@@ -7,7 +7,6 @@ import { Button } from '../../core/Button';
 import { ViewportWidth } from '../../../theme';
 import { ReactComponent as GovernanceIcon } from '../../icons/circle/gavel.svg';
 import { useConnected, useConnect } from '../../../context/OnboardProvider';
-import { useToggleWallet } from '../../../context/AppProvider';
 
 const Symbol = styled.div`
   align-items: center;
@@ -192,7 +191,7 @@ const Start: FC<{}> = () => {
 const GetStarted: FC<{}> = () => {
   const connect = useConnect();
   const connected = useConnected();
-  const toggleWallet = useToggleWallet();
+  const history = useHistory();
   return (
     <>
       <SymbolBlock>
@@ -203,8 +202,17 @@ const GetStarted: FC<{}> = () => {
       <Block>
         <P>Start by connecting your Ethereum wallet</P>
         <P>
-          <Button type="button" onClick={connected ? toggleWallet : connect}>
-            Connect
+          <Button
+            type="button"
+            onClick={() => {
+              if (connected) {
+                history.push('/mint');
+              } else {
+                connect();
+              }
+            }}
+          >
+            {connected ? 'Go to app' : 'Connect'}
           </Button>
         </P>
       </Block>

--- a/src/context/earn/transformEarnData.ts
+++ b/src/context/earn/transformEarnData.ts
@@ -285,6 +285,7 @@ const getStakingRewardsContractsMap = (
           // percentage = gains / stakingTokenPrice
           const percentage = gains / stakingTokenPrice;
 
+          // eslint-disable-next-line no-console
           console.log({
             rewardsTokenPrice,
             deltaR,


### PR DESCRIPTION
Changes:

- `GetStarted` now has a `Go to app` button once a user is connected with their wallet

![img](https://user-images.githubusercontent.com/23094095/103641202-ab4fa180-4f51-11eb-9cac-c2064f333216.png)
