### PR TITLE
Savings Rewards component

### DIFF
--- a/src/components/core/Button.tsx
+++ b/src/components/core/Button.tsx
@@ -38,10 +38,11 @@ export const BubbleButton = styled(UnstyledButton)<{
   }
 
   :hover {
-    background: ${({ theme, highlighted }) =>
-      highlighted ? theme.color.gold : `#eee`};
-    color: ${({ theme, highlighted }) =>
-      highlighted ? theme.color.white : theme.color.black};
+    ${({ disabled, theme, highlighted }) =>
+      !disabled && {
+        background: `${highlighted ? theme.color.gold : `#eee`}`,
+        color: `${highlighted ? theme.color.white : theme.color.black}`,
+      }}
   }
 `;
 

--- a/src/components/core/Tabs.tsx
+++ b/src/components/core/Tabs.tsx
@@ -28,7 +28,7 @@ export const TabBtn = styled(UnstyledButton)<{ active: boolean }>`
     active ? Color.blueTransparent : 'transparent'};
   color: ${({ active }) => (active ? Color.blue : Color.grey)};
   padding: 0.75rem 0.5rem;
-  font-weight: bold;
+  font-weight: 600;
   font-size: 1.75rem;
   width: 100%;
 

--- a/src/components/core/Widget.tsx
+++ b/src/components/core/Widget.tsx
@@ -39,8 +39,11 @@ const Header = styled.div`
 `;
 
 const Container = styled.div<Pick<Props, 'border'>>`
-  padding: ${({ border }) => (border ? '1rem' : '0')};
-  border: ${({ border }) => (border ? '1px #eee solid' : 0)};
+  ${({ border }) => ({
+    padding: border ? '1.25rem' : '0',
+    border: border ? '1px #eee solid' : 0,
+    borderRadius: border ? '0.75rem' : 'none',
+  })}
 `;
 
 export const Widget: FC<Props> = ({

--- a/src/components/core/Widget.tsx
+++ b/src/components/core/Widget.tsx
@@ -10,15 +10,14 @@ interface Props {
   headerContent?: ReactNode;
 }
 
-const Title = styled.div`
-  font-size: 1.2rem;
-  font-weight: bold;
+const Title = styled.h3`
+  font-weight: 600;
+  font-size: 1.25rem;
+  color: ${({ theme }) => theme.color.black};
 `;
 
 const Body = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
   gap: 2rem;
 
   > * {
@@ -33,12 +32,14 @@ const HeaderContent = styled.div`
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
+  margin-bottom: 1rem;
   gap: 1rem;
-  padding: 1rem 0;
+  height: 2rem;
+  overflow: hidden;
 `;
 
 const Container = styled.div<Pick<Props, 'border'>>`
-  padding: ${({ border }) => (border ? '1rem' : '1rem 0')};
+  padding: ${({ border }) => (border ? '1rem' : '0')};
   border: ${({ border }) => (border ? '1px #eee solid' : 0)};
 `;
 

--- a/src/components/pages/Save/v2/AssetExchange.tsx
+++ b/src/components/pages/Save/v2/AssetExchange.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
     display: flex;
     justify-content: space-between;
 
-    @media (min-width: ${ViewportWidth.xl}) {
+    @media (min-width: ${ViewportWidth.l}) {
       flex-direction: row;
     }
   }
@@ -34,45 +34,43 @@ const Details = styled.div`
     margin-top: 0.75rem;
   }
 
-  @media (min-width: ${ViewportWidth.xl}) {
+  @media (min-width: ${ViewportWidth.l}) {
     > * {
-      flex-basis: 45%;
+      flex-basis: 47.5%;
     }
   }
 `;
 
 const InputBox = styled(AssetInputBox)`
-  flex-basis: 45%;
+  flex-basis: 47.5%;
 `;
 
 const ArrowContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-basis: 10%;
+  flex: 1;
   margin: 0.5rem 0;
 
-  @media (min-width: ${ViewportWidth.xl}) {
+  @media (min-width: ${ViewportWidth.l}) {
     margin: 0;
   }
 `;
 
 const Arrow = styled.div`
-  width: 3rem;
-  height: 3rem;
   border-radius: 1.5rem;
   text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #eee;
 
-  @media (min-width: ${ViewportWidth.xl}) {
+  @media (min-width: ${ViewportWidth.l}) {
     span {
       visibility: hidden;
     }
     span:before {
       content: '→';
+      font-size: 1.25rem;
       visibility: visible;
       left: 0;
       right: 0;

--- a/src/components/pages/Save/v2/AssetInputBox.tsx
+++ b/src/components/pages/Save/v2/AssetInputBox.tsx
@@ -2,43 +2,26 @@ import React, { FC, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { Fields } from '../../../../types';
+import { Widget } from '../../../core/Widget';
 import { AssetTokenInput } from './AssetTokenInput';
 import { useSaveDispatch, useSaveState } from './SaveProvider';
 
 interface Props {
+  className?: string;
   fieldType: Fields;
   title: string;
   showExchangeRate?: boolean;
-  className?: string;
 }
 
 const { Input } = Fields;
 
-const Header = styled.div`
-  padding: 0.75rem;
-  display: flex;
-  justify-content: space-between;
+const ExchangeRate = styled.p`
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.color.grey};
 
-  h3 {
-    font-weight: 600;
-    font-size: 1.25rem;
-    color: ${({ theme }) => theme.color.black};
+  span {
+    ${({ theme }) => theme.mixins.numeric};
   }
-
-  p {
-    font-size: 0.875rem;
-    color: ${({ theme }) => theme.color.grey};
-  }
-`;
-
-const Body = styled.div`
-  padding: 0.75rem;
-`;
-
-const Container = styled.div`
-  padding: 0.75rem;
-  border: 1px solid #eee;
-  border-radius: 0.75rem;
 `;
 
 export const AssetInputBox: FC<Props> = ({
@@ -73,33 +56,39 @@ export const AssetInputBox: FC<Props> = ({
   }, [fieldType, inputToken, outputToken]);
 
   return (
-    <Container className={className}>
-      <Header>
-        <h3>{title}</h3>
-        {showExchangeRate && tokensAvailable && (
-          <p>
-            {`1 ${input.token?.symbol} = ${formattedExchangeRate} ${output.token?.symbol}`}
-          </p>
-        )}
-      </Header>
-      <Body>
-        <AssetTokenInput
-          name={fieldType}
-          amount={{
-            formValue: field?.formValue,
-            disabled: !isInput,
-            handleChange: isInput ? setInput : undefined,
-            handleSetMax: isInput ? setMaxInput : undefined,
-          }}
-          token={{
-            address: field?.token?.address,
-            addresses: tokenAddresses,
-            // disabled: !isInput,
-            handleChange: setToken,
-          }}
-          error={isInput ? error : undefined}
-        />
-      </Body>
-    </Container>
+    <Widget
+      className={className}
+      title={title}
+      border
+      headerContent={
+        showExchangeRate &&
+        tokensAvailable && (
+          <ExchangeRate>
+            <span>1</span>
+            {` `}
+            {input.token?.symbol}
+            <span> = {formattedExchangeRate}</span>
+            {` ${output.token?.symbol}`}
+          </ExchangeRate>
+        )
+      }
+    >
+      <AssetTokenInput
+        name={fieldType}
+        amount={{
+          formValue: field?.formValue,
+          disabled: !isInput,
+          handleChange: isInput ? setInput : undefined,
+          handleSetMax: isInput ? setMaxInput : undefined,
+        }}
+        token={{
+          address: field?.token?.address,
+          addresses: tokenAddresses,
+          // disabled: !isInput,
+          handleChange: setToken,
+        }}
+        error={isInput ? error : undefined}
+      />
+    </Widget>
   );
 };

--- a/src/components/pages/Save/v2/AssetInputBox.tsx
+++ b/src/components/pages/Save/v2/AssetInputBox.tsx
@@ -14,12 +14,6 @@ interface Props {
 
 const { Input } = Fields;
 
-const Container = styled.div`
-  padding: 0.75rem;
-  border: 1px solid #eee;
-  border-radius: 0.75rem;
-`;
-
 const Header = styled.div`
   padding: 0.75rem;
   display: flex;
@@ -39,6 +33,12 @@ const Header = styled.div`
 
 const Body = styled.div`
   padding: 0.75rem;
+`;
+
+const Container = styled.div`
+  padding: 0.75rem;
+  border: 1px solid #eee;
+  border-radius: 0.75rem;
 `;
 
 export const AssetInputBox: FC<Props> = ({

--- a/src/components/pages/Save/v2/Boost.tsx
+++ b/src/components/pages/Save/v2/Boost.tsx
@@ -17,6 +17,7 @@ import { ViewportWidth } from '../../../../theme';
 import { BigDecimal } from '../../../../web3/BigDecimal';
 import { AssetTokenInput } from './AssetTokenInput';
 import { Fields } from '../../../../types';
+import { SavingsReward } from './SavingsReward';
 
 const MAX_BOOST = 1.5;
 const MIN_BOOST = 0.5;
@@ -271,22 +272,27 @@ const BoostBar: FC = () => {
   );
 };
 
-const Rewards: FC = () => (
-  <Widget title="Savings Rewards">TODO add rewards</Widget>
-);
-
 const Container = styled.div`
   display: flex;
   gap: 2rem;
   justify-content: space-between;
   flex-direction: column;
-
-  @media (min-width: ${ViewportWidth.m}) {
-    flex-direction: row;
-  }
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #eee;
+  margin: 1rem 0;
 
   > * {
     flex: 1;
+  }
+
+  @media (min-width: ${ViewportWidth.l}) {
+    flex-direction: row;
+    align-items: space-between;
+
+    > * {
+      flex: 0;
+      flex-basis: 47.5%;
+    }
   }
 `;
 
@@ -295,7 +301,7 @@ const BoostContent: FC = () => {
   return (
     <Container>
       {showCalculator ? <Calculator /> : <BoostBar />}
-      <Rewards />
+      <SavingsReward />
     </Container>
   );
 };

--- a/src/components/pages/Save/v2/Boost.tsx
+++ b/src/components/pages/Save/v2/Boost.tsx
@@ -278,7 +278,6 @@ const Container = styled.div`
   justify-content: space-between;
   flex-direction: column;
   padding-bottom: 1rem;
-  border-bottom: 1px solid #eee;
   margin: 1rem 0;
 
   > * {

--- a/src/components/pages/Save/v2/SavingsReward.tsx
+++ b/src/components/pages/Save/v2/SavingsReward.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import styled from 'styled-components';
+import { ViewportWidth } from '../../../../theme';
 import { BigDecimal } from '../../../../web3/BigDecimal';
 
 import { BubbleButton as Button } from '../../../core/Button';
@@ -21,6 +22,10 @@ const SkeleWrapper = styled.div`
   }
 `;
 
+const PreviewText = styled.span`
+  color: ${({ theme }) => theme.color.green};
+`;
+
 const Line = styled.div`
   background: #eee;
   height: 2px;
@@ -32,12 +37,30 @@ const Line = styled.div`
 const RowContainer = styled.div`
   display: flex;
   align-items: center;
+
+  span {
+    ${({ theme }) => theme.mixins.numeric}
+  }
 `;
 
 const ButtonContainer = styled.div`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
+  margin-top: 1rem;
+
+  > button {
+    flex: 1;
+  }
+
+  @media (min-width: ${ViewportWidth.m}) {
+    margin: 0;
+    justify-content: flex-end;
+
+    > button {
+      flex: initial;
+    }
+  }
 `;
 
 const Stats = styled.div`
@@ -46,11 +69,28 @@ const Stats = styled.div`
   }
 `;
 
-const Body = styled.div`
+const Body = styled.div<{ isPreview?: boolean }>`
   display: flex;
+  flex-direction: column;
 
-  > div {
-    flex-basis: 50%;
+  @media (min-width: ${ViewportWidth.m}) {
+    flex-direction: row;
+
+    > div:first-child {
+      flex-basis: 65%;
+    }
+    > div:last-child {
+      flex-basis: 35%;
+    }
+  }
+
+  @media (min-width: ${ViewportWidth.l}) {
+    > div:first-child {
+      flex-basis: ${({ isPreview }) => (isPreview ? `70%` : `50%`)};
+    }
+    > div:last-child {
+      flex-basis: ${({ isPreview }) => (isPreview ? `30%` : `50%`)};
+    }
   }
 `;
 
@@ -67,16 +107,23 @@ const Row: FC<{
   title: string;
   tip?: string;
   value?: BigDecimal;
-}> = ({ title, tip, value }) => {
-  const formattedValue = value?.format(4);
+  preview?: BigDecimal;
+}> = ({ title, tip, value, preview }) => {
+  const formattedValue = value?.format(!!preview ? 2 : 4);
+  const formattedPreview = preview?.format(2);
   return (
     <RowContainer>
-      <span>{title}</span>
+      {title}
       {tip && <Tooltip tip={tip} />}
       {value ? (
         <>
           <Line />
           <span>{formattedValue}</span>
+          {!!formattedPreview && (
+            <span>
+              &nbsp;→ <PreviewText>{`${formattedPreview}`}</PreviewText>
+            </span>
+          )}
         </>
       ) : (
         <SkeleWrapper>
@@ -112,15 +159,25 @@ export const SavingsReward: FC = () => {
 
   return (
     <Widget title="Savings Rewards">
-      <Body>
+      <Body isPreview={!!simulatedValues}>
         <Stats>
           <Row
             title="Claimable"
             tip="Tooltip title"
+            preview={simulatedValues?.claimable}
             value={values?.claimable}
           />
-          <Row title="Vesting" tip="Tooltip title" value={values?.vesting} />
-          <Row title="Wallet" value={values?.wallet} />
+          <Row
+            title="Vesting"
+            tip="Tooltip title"
+            preview={simulatedValues?.vesting}
+            value={values?.vesting}
+          />
+          <Row
+            title="Wallet"
+            preview={simulatedValues?.wallet}
+            value={values?.wallet}
+          />
         </Stats>
         <ButtonContainer>
           <Button
@@ -128,7 +185,7 @@ export const SavingsReward: FC = () => {
             disabled={loading}
             highlighted={!!simulatedValues}
           >
-            {simulatedValues ? `Claim` : `Claim Preview`}
+            {simulatedValues ? `Claim` : `Preview Claim`}
           </Button>
         </ButtonContainer>
       </Body>

--- a/src/components/pages/Save/v2/SavingsReward.tsx
+++ b/src/components/pages/Save/v2/SavingsReward.tsx
@@ -1,0 +1,157 @@
+import React, { FC, useEffect, useMemo, useState } from 'react';
+import Skeleton from 'react-loading-skeleton';
+import styled from 'styled-components';
+import { BigDecimal } from '../../../../web3/BigDecimal';
+
+import { BubbleButton as Button } from '../../../core/Button';
+import { Tooltip } from '../../../core/ReactTooltip';
+
+type SavingValues = {
+  [key in 'claimable' | 'vesting' | 'wallet']: BigDecimal;
+};
+
+const SkeleWrapper = styled.div`
+  flex: 1;
+  margin-left: 1.25rem;
+
+  span {
+    flex: 1;
+    display: flex;
+  }
+`;
+
+const Line = styled.div`
+  background: #eee;
+  height: 2px;
+  margin: 0 1.25rem;
+  flex: 1;
+  display: flex;
+`;
+
+const RowContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 0.75rem 0;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const Stats = styled.div``;
+
+const Body = styled.div`
+  display: flex;
+
+  > div {
+    flex-basis: 50%;
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+
+  h3 {
+    font-weight: 600;
+    font-size: 1.25rem;
+    color: ${({ theme }) => theme.color.black};
+  }
+
+  p {
+    font-size: 0.875rem;
+    color: ${({ theme }) => theme.color.grey};
+  }
+`;
+
+const Container = styled.div`
+  background: #ccc;
+`;
+
+const simulateValues = (values: SavingValues): SavingValues => {
+  const { claimable, vesting, wallet } = values;
+  return {
+    claimable: claimable?.add(new BigDecimal((1e18).toString())),
+    vesting: vesting?.add(new BigDecimal((1e18).toString())),
+    wallet: wallet?.add(new BigDecimal((1e18).toString())),
+  };
+};
+
+const Row: FC<{
+  title: string;
+  tip?: string;
+  value?: BigDecimal;
+}> = ({ title, tip, value }) => {
+  const formattedValue = value?.format(4);
+  return (
+    <RowContainer>
+      <span>{title}</span>
+      {tip && <Tooltip tip={tip} />}
+      {!!value ? (
+        <>
+          <Line />
+          <span>{formattedValue}</span>
+        </>
+      ) : (
+        <SkeleWrapper>
+          <Skeleton height={8} />
+        </SkeleWrapper>
+      )}
+    </RowContainer>
+  );
+};
+
+export const SavingsReward: FC = () => {
+  // temporary
+  const loading = false;
+
+  const [simulatedValues, setSimulated] = useState<SavingValues | undefined>();
+
+  const values = useMemo((): SavingValues | undefined => {
+    // wait for all values
+    if (loading) return;
+    return {
+      claimable: new BigDecimal((3e18).toString()),
+      vesting: new BigDecimal((3e18).toString()),
+      wallet: new BigDecimal((3e18).toString()),
+    };
+  }, []);
+
+  const handleClick = () => {
+    if (values === undefined) return;
+
+    const newValues = simulateValues(values);
+    setSimulated(simulatedValues ? undefined : newValues);
+  };
+
+  return (
+    <Container>
+      <Header>
+        <h3>Savings Rewards</h3>
+      </Header>
+      <Body>
+        <Stats>
+          <Row
+            title="Claimable"
+            tip="Tooltip title"
+            value={values?.claimable}
+          />
+          <Row title="Vesting" tip="Tooltip title" value={values?.vesting} />
+          <Row title="Wallet" value={values?.wallet} />
+        </Stats>
+        <ButtonContainer>
+          <Button
+            onClick={handleClick}
+            disabled={loading}
+            highlighted={!!simulatedValues}
+          >
+            {simulatedValues ? `Claim` : `Claim Preview`}
+          </Button>
+        </ButtonContainer>
+      </Body>
+    </Container>
+  );
+};

--- a/src/components/pages/Save/v2/SavingsReward.tsx
+++ b/src/components/pages/Save/v2/SavingsReward.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import styled from 'styled-components';
 import { useSelectedMassetState } from '../../../../context/DataProvider/DataProvider';
@@ -161,18 +161,14 @@ export const SavingsReward: FC = () => {
     if (!simulatedValues) {
       const newValues = simulateValues(values);
       setSimulated(simulatedValues ? undefined : newValues);
+      setTimeout(() => {
+        setSimulated(undefined);
+      }, 10000);
     }
 
     // TODO: - claim function call here
     // claimRewards();
   };
-
-  useEffect(() => {
-    if (!simulatedValues) return;
-    setTimeout(() => {
-      setSimulated(undefined);
-    }, 10000);
-  }, [simulatedValues]);
 
   const isButtonDisabled = loading || values?.claimable.exact.eq(0);
 

--- a/src/components/pages/Save/v2/SavingsReward.tsx
+++ b/src/components/pages/Save/v2/SavingsReward.tsx
@@ -182,13 +182,13 @@ export const SavingsReward: FC = () => {
         <Stats>
           <Row
             title="Claimable"
-            tip="Tooltip title"
+            tip="Earned + Unlocked tokens"
             preview={simulatedValues?.claimable}
             value={values?.claimable}
           />
           <Row
             title="Vesting"
-            tip="Tooltip title"
+            tip="These tokens will unlock over time"
             preview={simulatedValues?.vesting}
             value={values?.vesting}
           />

--- a/src/components/pages/Save/v2/SavingsReward.tsx
+++ b/src/components/pages/Save/v2/SavingsReward.tsx
@@ -1,10 +1,11 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import styled from 'styled-components';
 import { BigDecimal } from '../../../../web3/BigDecimal';
 
 import { BubbleButton as Button } from '../../../core/Button';
 import { Tooltip } from '../../../core/ReactTooltip';
+import { Widget } from '../../../core/Widget';
 
 type SavingValues = {
   [key in 'claimable' | 'vesting' | 'wallet']: BigDecimal;
@@ -31,7 +32,7 @@ const Line = styled.div`
 const RowContainer = styled.div`
   display: flex;
   align-items: center;
-  margin: 0.75rem 0;
+  margin-bottom: 0.75rem;
 `;
 
 const ButtonContainer = styled.div`
@@ -44,31 +45,11 @@ const Stats = styled.div``;
 
 const Body = styled.div`
   display: flex;
+  padding-bottom: 1rem;
 
   > div {
     flex-basis: 50%;
   }
-`;
-
-const Header = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 0.75rem;
-
-  h3 {
-    font-weight: 600;
-    font-size: 1.25rem;
-    color: ${({ theme }) => theme.color.black};
-  }
-
-  p {
-    font-size: 0.875rem;
-    color: ${({ theme }) => theme.color.grey};
-  }
-`;
-
-const Container = styled.div`
-  background: #ccc;
 `;
 
 const simulateValues = (values: SavingValues): SavingValues => {
@@ -90,7 +71,7 @@ const Row: FC<{
     <RowContainer>
       <span>{title}</span>
       {tip && <Tooltip tip={tip} />}
-      {!!value ? (
+      {value ? (
         <>
           <Line />
           <span>{formattedValue}</span>
@@ -118,9 +99,9 @@ export const SavingsReward: FC = () => {
       vesting: new BigDecimal((3e18).toString()),
       wallet: new BigDecimal((3e18).toString()),
     };
-  }, []);
+  }, [loading]);
 
-  const handleClick = () => {
+  const handleClick = (): void => {
     if (values === undefined) return;
 
     const newValues = simulateValues(values);
@@ -128,10 +109,7 @@ export const SavingsReward: FC = () => {
   };
 
   return (
-    <Container>
-      <Header>
-        <h3>Savings Rewards</h3>
-      </Header>
+    <Widget title="Savings Rewards">
       <Body>
         <Stats>
           <Row
@@ -152,6 +130,6 @@ export const SavingsReward: FC = () => {
           </Button>
         </ButtonContainer>
       </Body>
-    </Container>
+    </Widget>
   );
 };

--- a/src/components/pages/Save/v2/SavingsReward.tsx
+++ b/src/components/pages/Save/v2/SavingsReward.tsx
@@ -32,7 +32,6 @@ const Line = styled.div`
 const RowContainer = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 0.75rem;
 `;
 
 const ButtonContainer = styled.div`
@@ -41,11 +40,14 @@ const ButtonContainer = styled.div`
   justify-content: flex-end;
 `;
 
-const Stats = styled.div``;
+const Stats = styled.div`
+  > div:not(:last-child) {
+    margin-bottom: 0.75rem;
+  }
+`;
 
 const Body = styled.div`
   display: flex;
-  padding-bottom: 1rem;
 
   > div {
     flex-basis: 50%;


### PR DESCRIPTION
## Adds:
- Adds new SavingRewards component with the following:
  - Preview state + timeout
  - 'No rewards' state
  - Loading state
- Updates Widget UI
- Updates AssetInputBox to use Widget for consistency
- Fixes BubbleButton disabled state

## Screenshots
|  Desktop XL (Loading) 
| --- | 
| <img width="565" alt="Screenshot 2021-01-07 at 13 14 22" src="https://user-images.githubusercontent.com/19643324/103899013-aaec0d80-50ed-11eb-8b11-25be6e2adccc.png">| 

|  Desktop XL (Preview) |  Desktop XL (Claim)
| --- | --- |
| <img width="518" alt="Screenshot 2021-01-07 at 13 13 57" src="https://user-images.githubusercontent.com/19643324/103898797-619bbe00-50ed-11eb-881f-30802a3d79e3.png"> | <img width="513" alt="Screenshot 2021-01-07 at 13 38 10" src="https://user-images.githubusercontent.com/19643324/103898966-9871d400-50ed-11eb-855b-e5c6c2b5899f.png"> |

|  Desktop M (Preview)
| --- | 
| <img width="861" alt="Screenshot 2021-01-07 at 13 14 42" src="https://user-images.githubusercontent.com/19643324/103899128-d66ef800-50ed-11eb-8751-caf128aed4ae.png"> |

|  Desktop M (Claim)
| --- | 
| <img width="909" alt="Screenshot 2021-01-07 at 13 40 14" src="https://user-images.githubusercontent.com/19643324/103899145-e1298d00-50ed-11eb-8105-5945f216ebb3.png"> |

|  Desktop S (Preview) |  Desktop S (Claim)
| --- | --- |
| <img width="522" alt="Screenshot 2021-01-07 at 13 14 57" src="https://user-images.githubusercontent.com/19643324/103899221-fd2d2e80-50ed-11eb-83f0-b13cb5de76b5.png"> | <img width="436" alt="Screenshot 2021-01-07 at 13 41 15" src="https://user-images.githubusercontent.com/19643324/103899242-05856980-50ee-11eb-83a4-f14e7477c86e.png"> |