### PR TITLE
Show staked & non-staked savings (UI only)

### DIFF
--- a/src/components/core/Button.tsx
+++ b/src/components/core/Button.tsx
@@ -20,7 +20,8 @@ export const BubbleButton = styled(UnstyledButton)<{
   disabled?: boolean;
 }>`
   font-size: ${({ scale }) => (scale ? `${scale}rem` : `1rem`)};
-  padding: 0.75em 1.5em;
+  padding: ${({ scale }) =>
+    scale ? `${scale * 0.75}em ${scale * 1.5}em` : `1rem`};
   border-radius: 1.5em;
   background: ${({ theme, highlighted }) =>
     highlighted ? theme.color.blue : `#eee`};

--- a/src/components/core/Tabs.tsx
+++ b/src/components/core/Tabs.tsx
@@ -3,7 +3,7 @@ import { UnstyledButton } from './Button';
 import { Color, FontSize, ViewportWidth } from '../../theme';
 
 export const TabsContainer = styled.div`
-  padding: 16px 0;
+  margin-bottom: 0.75rem;
   display: flex;
   justify-content: space-evenly;
 
@@ -20,12 +20,8 @@ export const TabsContainer = styled.div`
 
 export const TabBtn = styled(UnstyledButton)<{ active: boolean }>`
   cursor: pointer;
-  border: ${({ active, theme }) =>
-    `1px ${
-      active ? theme.color.blueTransparent : theme.color.lightGrey
-    } solid`};
-  background: ${({ active }) =>
-    active ? Color.blueTransparent : 'transparent'};
+  border: ${({ theme }) => `1px ${theme.color.blueTransparent} solid`};
+  background: transparent;
   color: ${({ active }) => (active ? Color.blue : Color.grey)};
   padding: 0.75rem 0.5rem;
   font-weight: 600;

--- a/src/components/core/Widget.tsx
+++ b/src/components/core/Widget.tsx
@@ -4,14 +4,15 @@ import { Tooltip } from './ReactTooltip';
 
 interface Props {
   className?: string;
-  title: string;
+  title?: string;
   tooltip?: string;
   border?: boolean;
   headerContent?: ReactNode;
+  boldTitle?: boolean;
 }
 
-const Title = styled.h3`
-  font-weight: 600;
+const Title = styled.h3<{ bold?: boolean }>`
+  font-weight: ${({ bold }) => bold && 600};
   font-size: 1.25rem;
   color: ${({ theme }) => theme.color.black};
 `;
@@ -32,7 +33,7 @@ const HeaderContent = styled.div`
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   gap: 1rem;
   height: 2rem;
   overflow: hidden;
@@ -53,19 +54,23 @@ export const Widget: FC<Props> = ({
   headerContent,
   title,
   tooltip,
+  boldTitle,
 }) => {
+  const showHeader = !!title || !!tooltip;
   return (
     <Container border={border} className={className}>
-      <Header>
-        {tooltip ? (
-          <Tooltip tip={tooltip}>
-            <Title>{title}</Title>
-          </Tooltip>
-        ) : (
-          <Title>{title}</Title>
-        )}
-        {headerContent && <HeaderContent>{headerContent}</HeaderContent>}
-      </Header>
+      {showHeader && (
+        <Header>
+          {tooltip ? (
+            <Tooltip tip={tooltip}>
+              <Title>{title}</Title>
+            </Tooltip>
+          ) : (
+            <Title bold={boldTitle}>{title}</Title>
+          )}
+          {headerContent && <HeaderContent>{headerContent}</HeaderContent>}
+        </Header>
+      )}
       <Body>{children}</Body>
     </Container>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -40,7 +40,6 @@ const Container = styled.header<{ accountOpen: boolean; home: boolean }>`
   justify-content: center;
   background: ${({ accountOpen, theme }) =>
     accountOpen ? theme.color.black : theme.color.white};
-  margin-bottom: 2rem;
 `;
 
 export const Header: FC<{ home: boolean }> = ({ home }) => {

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -19,7 +19,7 @@ const Item = styled.li<{
   position: relative;
   font-weight: 600;
   font-size: 1.4rem;
-  padding: 1.5rem 0;
+  padding: 3rem 0;
 
   a,
   span {

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -12,6 +12,7 @@ import { Widget } from '../../core/Widget';
 import { BigDecimal } from '../../../web3/BigDecimal';
 import { useAverageApyForPastWeek } from '../../../web3/hooks';
 import { ViewportWidth } from '../../../theme';
+import { BubbleButton as Button } from '../../core/Button';
 
 const Title = styled.div`
   display: flex;
@@ -20,6 +21,14 @@ const Title = styled.div`
 const Subtitle = styled.div`
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
+`;
+
+const Interest = styled.h4`
+  align-items: center;
+
+  button {
+    margin-left: 0.5rem;
+  }
 `;
 
 const StyledWarningBadge = styled(WarningBadge)`
@@ -90,10 +99,17 @@ const Row: FC<{
       </div>
       <div>
         <Subtitle>Interest:</Subtitle>
-        <h4>
+        <Interest>
           <span>{`${interest?.toFixed(2) ?? `0.00`}%`}</span>&nbsp;
-          {boosted && `+ MTA`}
-        </h4>
+          {boosted ? (
+            `+ MTA`
+          ) : (
+            // TODO: - Hookup to v2 stake function call
+            <Button highlighted scale={0.7} onClick={() => {}}>
+              Stake
+            </Button>
+          )}
+        </Interest>
       </div>
       <div>
         <Subtitle>Balance</Subtitle>
@@ -116,7 +132,7 @@ export const SaveInfo: FC = () => {
 
   // TODO: - Balance should be wallet balance for imUSD
   // Should also split between v1 & v2 state for determing balance, eg from SC vs wallet for v2
-  const balance = undefined; // new BigDecimal((1e18).toString());
+  const balance = new BigDecimal((1e18).toString());
   const stakedBalance = savingsContractState?.savingsBalance?.balance;
 
   return (

--- a/src/components/pages/Save/SaveInfo.tsx
+++ b/src/components/pages/Save/SaveInfo.tsx
@@ -11,6 +11,7 @@ import { SaveMigration } from './SaveMigration';
 import { Widget } from '../../core/Widget';
 import { BigDecimal } from '../../../web3/BigDecimal';
 import { useAverageApyForPastWeek } from '../../../web3/hooks';
+import { ViewportWidth } from '../../../theme';
 
 const Title = styled.div`
   display: flex;
@@ -46,6 +47,15 @@ const StyledWidget = styled(Widget)`
   }
   span {
     ${({ theme }) => theme.mixins.numeric};
+  }
+  > div {
+    flex-direction: column;
+  }
+
+  @media (min-width: ${ViewportWidth.m}) {
+    > div {
+      flex-direction: row;
+    }
   }
 `;
 

--- a/src/components/pages/Save/SaveMigration.tsx
+++ b/src/components/pages/Save/SaveMigration.tsx
@@ -28,7 +28,7 @@ const Inner = styled.div`
 `;
 
 const Card = styled.div`
-  margin-top: 2.5rem;
+  margin-top: 1.5rem;
   padding: 1.5rem;
   border-radius: 1.5rem;
   position: relative;

--- a/src/components/pages/Save/v2/AssetInputBox.tsx
+++ b/src/components/pages/Save/v2/AssetInputBox.tsx
@@ -60,6 +60,7 @@ export const AssetInputBox: FC<Props> = ({
       className={className}
       title={title}
       border
+      boldTitle
       headerContent={
         showExchangeRate &&
         tokensAvailable && (

--- a/src/components/pages/Save/v2/Boost.tsx
+++ b/src/components/pages/Save/v2/Boost.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as ArrowsSvg } from '../../../icons/double-arrow.svg';
 import { ReactComponent as GovSvg } from '../../../icons/governance-icon.svg';
 import { DifferentialCountup } from '../../../core/CountUp';
 import { ProgressBar } from '../../../core/ProgressBar';
-import { Button, UnstyledButton } from '../../../core/Button';
+import { BubbleButton, Button, UnstyledButton } from '../../../core/Button';
 import { Widget } from '../../../core/Widget';
 import { ViewportWidth } from '../../../../theme';
 import { BigDecimal } from '../../../../web3/BigDecimal';
@@ -169,7 +169,11 @@ export const Calculator: FC = () => {
     <CalculatorWidget
       title="Savings Boost Calculator"
       tooltip="Find out how to get the optimal boost"
-      headerContent={<Button onClick={toggleShowCalculator}>Back</Button>}
+      headerContent={
+        <BubbleButton scale={0.7} onClick={toggleShowCalculator}>
+          Back
+        </BubbleButton>
+      }
     >
       <CalculatorInputs>
         <div>
@@ -252,7 +256,11 @@ const BoostBar: FC = () => {
     <Widget
       title="Savings Boost"
       tooltip="Save rewards are boosted by a multiplier (from 0.5 to 1.5)"
-      headerContent={<Button onClick={toggleShowCalculator}>Calculator</Button>}
+      headerContent={
+        <BubbleButton scale={0.7} onClick={toggleShowCalculator}>
+          Calculator
+        </BubbleButton>
+      }
     >
       <div>
         <ProgressBar
@@ -272,25 +280,31 @@ const BoostBar: FC = () => {
   );
 };
 
-const Container = styled.div`
-  display: flex;
-  gap: 2rem;
-  justify-content: space-between;
-  flex-direction: column;
-  padding-bottom: 1rem;
-  margin: 1rem 0;
+const Container = styled(Widget)<{ showCalculator?: boolean }>`
+  margin-bottom: 0.75rem;
 
-  > * {
+  > div {
+    display: flex;
+    gap: 2rem;
+    justify-content: space-between;
+    flex-direction: column;
+  }
+
+  > div > * {
     flex: 1;
   }
 
   @media (min-width: ${ViewportWidth.l}) {
-    flex-direction: row;
-    align-items: space-between;
+    > div {
+      flex-direction: row;
+      align-items: space-between;
+      justify-content: space-between;
+    }
 
-    > * {
-      flex: 0;
-      flex-basis: 47.5%;
+    > div > * {
+      flex: ${({ showCalculator }) => !showCalculator && 0};
+      flex-basis: ${({ showCalculator }) =>
+        !showCalculator && `calc(47.5% - 0.75rem)`};
     }
   }
 `;
@@ -298,9 +312,15 @@ const Container = styled.div`
 const BoostContent: FC = () => {
   const [showCalculator] = useShowCalculatorCtx();
   return (
-    <Container>
-      {showCalculator ? <Calculator /> : <BoostBar />}
-      <SavingsReward />
+    <Container border showCalculator={showCalculator}>
+      {showCalculator ? (
+        <Calculator />
+      ) : (
+        <>
+          <BoostBar />
+          <SavingsReward />
+        </>
+      )}
     </Container>
   );
 };

--- a/src/components/pages/Save/v2/Boost.tsx
+++ b/src/components/pages/Save/v2/Boost.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as ArrowsSvg } from '../../../icons/double-arrow.svg';
 import { ReactComponent as GovSvg } from '../../../icons/governance-icon.svg';
 import { DifferentialCountup } from '../../../core/CountUp';
 import { ProgressBar } from '../../../core/ProgressBar';
-import { BubbleButton, Button, UnstyledButton } from '../../../core/Button';
+import { BubbleButton, UnstyledButton } from '../../../core/Button';
 import { Widget } from '../../../core/Widget';
 import { ViewportWidth } from '../../../../theme';
 import { BigDecimal } from '../../../../web3/BigDecimal';

--- a/src/components/pages/Save/v2/Deposit.tsx
+++ b/src/components/pages/Save/v2/Deposit.tsx
@@ -2,13 +2,11 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 
 import { AssetExchange } from './AssetExchange';
-import { Boost } from './Boost';
 
 const Container = styled.div``;
 
 export const Deposit: FC = () => (
   <Container>
-    <Boost />
     <AssetExchange />
   </Container>
 );

--- a/src/components/pages/Save/v2/index.tsx
+++ b/src/components/pages/Save/v2/index.tsx
@@ -6,6 +6,7 @@ import { TabsContainer, TabBtn } from '../../../core/Tabs';
 import { Deposit } from './Deposit';
 import { Withdraw } from './Withdraw';
 import { SaveMode } from './types';
+import { Boost } from './Boost';
 
 const MODE_TYPES = {
   [SaveMode.Deposit]: {
@@ -38,8 +39,12 @@ const TabButton: FC<{ tabMode: SaveMode }> = ({ tabMode }) => {
 const SaveForm: FC = () => {
   const { mode } = useSaveState();
 
+  // TODO: - Make boost conditionally render if use has staked balance
+  const userHasStaked = false;
+
   return (
     <Container>
+      {userHasStaked && <Boost />}
       <TabsContainer>
         <TabButton tabMode={SaveMode.Deposit} />
         <TabButton tabMode={SaveMode.Withdraw} />


### PR DESCRIPTION
## Adds:
- New UI for Save balance
- Adds placeholder for Staked Savings
- Combines Boost into Widget + fixes bug where Calculator doesn't span full length (I introduced it previously 👀 )
- Changes calculator button to scaled BubbleButton
- Adjusted padding for Nav
- Conditionally show balances + boost depending on user state

Default state is maybe a bit bare, and full-state (both balances, boost, etc) a bit full. It's a start though.

**Might give this a rethink at some point & merge Staked Savings + Boost views into one**

## Screenshots
|  Desktop (No balances) 
| --- | 
| <img width="1171" alt="Screenshot 2021-01-08 at 15 53 52" src="https://user-images.githubusercontent.com/19643324/104036268-1c4dbe00-51cb-11eb-89dd-f12d40d3ae3a.png">| 

|  Desktop M (imUSD balance)
| --- | 
| <img width="1170" alt="Screenshot 2021-01-08 at 15 54 37" src="https://user-images.githubusercontent.com/19643324/104036340-31c2e800-51cb-11eb-9d91-e076e472a3f0.png"> |

|  Desktop M (imUSD + staked imUSD)
| --- | 
| <img width="1166" alt="Screenshot 2021-01-08 at 15 55 24" src="https://user-images.githubusercontent.com/19643324/104036472-59b24b80-51cb-11eb-80e7-e91739d5e40b.png"> |

|  Mobile | Stake button
| --- | --- |
| <img width="484" alt="Screenshot 2021-01-08 at 16 14 25" src="https://user-images.githubusercontent.com/19643324/104037390-96cb0d80-51cc-11eb-9f14-0670f517301d.png"> | <img width="202" alt="Screenshot 2021-01-08 at 16 22 26" src="https://user-images.githubusercontent.com/19643324/104039025-bf073c00-51cd-11eb-843e-6a834dac2a3a.png"> |

