### PR TITLE
Fix save balance caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix an issue relating to caching of exchange rates
+
 ## Version 1.16.1
 
 - Fix an issue where some historic transactions with removed bAssets would not show

--- a/src/context/DataProvider/ApolloProvider.tsx
+++ b/src/context/DataProvider/ApolloProvider.tsx
@@ -20,7 +20,7 @@ import { useAddErrorNotification } from '../NotificationsProvider';
 
 const CHAIN_ID = process.env.REACT_APP_CHAIN_ID;
 
-const CACHE_KEY = `apollo-cache-persist.CHAIN_ID_${CHAIN_ID}.v2`;
+const CACHE_KEY = `apollo-cache-persist.CHAIN_ID_${CHAIN_ID}.v3`;
 
 const ENDPOINTS = {
   legacy: process.env.REACT_APP_GRAPHQL_ENDPOINT_LEGACY as string,
@@ -130,7 +130,7 @@ export const ApolloProvider: FC<{}> = ({ children }) => {
           nextFetchPolicy: 'cache-and-network',
         },
         query: {
-          fetchPolicy: 'cache-first',
+          fetchPolicy: 'cache-and-network' as never,
         },
       },
     });

--- a/src/context/DataProvider/DataProvider.tsx
+++ b/src/context/DataProvider/DataProvider.tsx
@@ -49,6 +49,9 @@ const useRawData = (): PartialRawData => {
 
   const latestExchangeRateSub = useBlockPollingSubscription(
     useLatestExchangeRateLazyQuery,
+    {
+      fetchPolicy: 'network-only',
+    },
   );
   const latestExchangeRate = latestExchangeRateSub.data?.exchangeRates[0];
 


### PR DESCRIPTION
- Do not cache latest exchange rate query; some users have reported save balances not increasing (superficially)
- Adjust Apollo fetch policies (may be unnecessary, but shouldn't cause problems other than more queries)
- Bump Apollo cache key to clear the cache