### PR TITLE
Dark mode 🌚

### DIFF
--- a/src/components/core/ActivitySpinner.tsx
+++ b/src/components/core/ActivitySpinner.tsx
@@ -22,7 +22,7 @@ const Spinner = styled.svg<Props>`
         : success
         ? theme.color.green
         : pending
-        ? theme.color.blue
+        ? theme.color.primary
         : theme.color.greyTransparent};
     stroke-width: ${({ size }) => (size ? `${(size * 8) / 50}px` : `8px`)};
     stroke-linecap: round;

--- a/src/components/core/Button.tsx
+++ b/src/components/core/Button.tsx
@@ -14,7 +14,7 @@ const ButtonCss = css<Props>`
     scale ? `${scale * 0.75}em ${scale * 1.5}em` : `1rem`};
   border-radius: 1.5em;
   background: ${({ theme, highlighted }) =>
-    highlighted ? theme.color.blue : `#eee`};
+    highlighted ? theme.color.primary : theme.color.accent};
   color: ${({ theme, highlighted }) =>
     highlighted ? theme.color.white : theme.color.grey};
   z-index: ${({ highlighted }) => (highlighted ? 1 : 0)};
@@ -31,7 +31,7 @@ const ButtonCss = css<Props>`
   :hover {
     ${({ disabled, theme, highlighted }) =>
       !disabled && {
-        background: `${highlighted ? theme.color.gold : `#eee`}`,
+        background: `${highlighted ? theme.color.gold : theme.color.accent}`,
         color: `${highlighted ? theme.color.white : theme.color.black}`,
       }}
   }

--- a/src/components/core/NotificationItem.tsx
+++ b/src/components/core/NotificationItem.tsx
@@ -34,7 +34,7 @@ const Container = styled.div<
     type === NotificationType.Success
       ? theme.color.green
       : type === NotificationType.Info || type === NotificationType.Update
-      ? theme.color.blue
+      ? theme.color.primary
       : theme.color.red};
   color: ${({ theme, type }) =>
     type === NotificationType.Success ? theme.color.black : theme.color.white};

--- a/src/components/core/ProgressBar.tsx
+++ b/src/components/core/ProgressBar.tsx
@@ -1,5 +1,7 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
+import { useThemeMode } from '../../context/AppProvider';
+import { colorTheme } from '../../theme';
 
 interface Props {
   value?: number;
@@ -25,6 +27,7 @@ export const ProgressBar: FC<Props> = ({
   color = '#67C73A',
   highlight = '#77D16F',
 }) => {
+  const themeMode = useThemeMode();
   const progressWidth = Math.max(
     ((value - min) / (max - min)) * WIDTH,
     HEIGHT * 2,
@@ -73,8 +76,7 @@ export const ProgressBar: FC<Props> = ({
           y={0}
           rx={HEIGHT / 2}
           ry={HEIGHT / 2}
-          fill="#f8f8f8"
-          stroke="#eee"
+          fill={colorTheme(themeMode).accent}
         />
         <rect
           width={progressWidth}

--- a/src/components/core/Step.tsx
+++ b/src/components/core/Step.tsx
@@ -67,7 +67,7 @@ const Options = styled.div`
     top: calc(50% - 0.125rem);
     width: 100%;
     height: 0.25rem;
-    background: ${({ theme }) => theme.color.lightGrey};
+    background: ${({ theme }) => theme.color.bodyTransparenter};
     content: '';
     z-index: -1;
   }
@@ -86,10 +86,10 @@ const Container = styled.div<{
       complete
         ? `4px solid ${theme.color.greenTransparent}`
         : active
-        ? `4px solid ${theme.color.blueTransparent}`
+        ? `4px solid ${theme.color.primaryTransparent}`
         : `none`};
     background: ${({ theme, active, complete }) =>
-      complete || active ? theme.color.white : theme.color.lightGrey};
+      complete || active ? theme.color.background : theme.color.lightGrey};
   }
 
   ${Title} {

--- a/src/components/core/Toggle.tsx
+++ b/src/components/core/Toggle.tsx
@@ -12,7 +12,7 @@ interface Props {
 const Container = styled.div`
   padding: 0;
   border-radius: 1.5rem;
-  background: #eee;
+  background: ${({ theme }) => theme.color.accent};
 
   button:not(:first-child) {
     margin-left: -0.5rem;

--- a/src/components/core/Widget.tsx
+++ b/src/components/core/Widget.tsx
@@ -17,7 +17,7 @@ interface Props {
 const Title = styled.h3<{ bold?: boolean }>`
   font-weight: 600;
   font-size: ${({ bold }) => (bold ? `1.25rem` : `1.125rem`)};
-  color: ${({ theme }) => theme.color.black};
+  color: ${({ theme }) => theme.color.body};
 `;
 
 const Body = styled.div`
@@ -53,9 +53,9 @@ const Header = styled.div`
 `;
 
 const Container = styled.div<{ border?: boolean; padding?: boolean }>`
-  ${({ border, padding }) => ({
+  ${({ border, padding, theme }) => ({
     padding: border || padding ? '1.25rem' : '0',
-    border: border ? '1px #eee solid' : 0,
+    border: border ? `1px ${theme.color.accent} solid` : 0,
     borderRadius: border ? '0.75rem' : 'none',
   })}
 `;
@@ -67,7 +67,7 @@ const ContainerButton = styled(UnstyledButton)<{
   width: 100%;
 
   :hover {
-    background: ${({ theme }) => theme.color.lighterGrey};
+    background: ${({ theme }) => theme.color.accent};
     cursor: pointer;
   }
 
@@ -75,9 +75,9 @@ const ContainerButton = styled(UnstyledButton)<{
     background: ${({ theme }) => theme.color.lightGrey};
   }
 
-  ${({ border, padding }) => ({
+  ${({ border, padding, theme }) => ({
     padding: border || padding ? '1.25rem' : '0',
-    border: border ? '1px #eee solid' : 0,
+    border: border ? `1px ${theme.color.accent} solid` : 0,
     borderRadius: border ? '0.75rem' : 'none',
   })}
 `;

--- a/src/components/forms/AmountInput.tsx
+++ b/src/components/forms/AmountInput.tsx
@@ -52,8 +52,8 @@ export const Input = styled.input<{
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'auto')};
 
   &:focus {
-    border-color: ${({ theme }) => theme.color.blue};
-    background: ${({ theme }) => theme.color.blueTransparent};
+    border-color: ${({ theme }) => theme.color.primary};
+    background: ${({ theme }) => theme.color.primaryTransparent};
   }
 
   ${({ theme }) => theme.mixins.numeric};

--- a/src/components/forms/AssetExchange.tsx
+++ b/src/components/forms/AssetExchange.tsx
@@ -74,7 +74,7 @@ const Info = styled.div`
   justify-content: space-between;
   height: fit-content;
   padding: 0.75rem;
-  border: 1px solid #eee;
+  border: 1px solid ${({ theme }) => theme.color.accent};
   border-radius: 0.75rem;
 `;
 

--- a/src/components/forms/SendButton.tsx
+++ b/src/components/forms/SendButton.tsx
@@ -30,7 +30,7 @@ const StyledButton = styled(Button)`
 `;
 
 const CloseButton = styled(UnstyledButton)`
-  background: #eee;
+  background: ${({ theme }) => theme.color.accent};
   width: 2.25rem;
   height: 2.25rem;
   text-align: center;

--- a/src/components/forms/TokenInput.tsx
+++ b/src/components/forms/TokenInput.tsx
@@ -62,7 +62,7 @@ const OptionContainer = styled.div<Pick<TokenOptionProps, 'selected'>>`
   overflow-x: hidden;
   padding: ${({ theme }) => theme.spacing.xs};
   background: ${({ selected, theme }) =>
-    selected ? theme.color.blueTransparent : 'transparent'};
+    selected ? theme.color.primaryTransparent : 'transparent'};
 
   img {
     padding-right: 6px;
@@ -70,7 +70,7 @@ const OptionContainer = styled.div<Pick<TokenOptionProps, 'selected'>>`
   }
 
   &:hover {
-    background: ${({ theme }) => theme.color.blueTransparent};
+    background: ${({ theme }) => theme.color.primaryTransparent};
   }
 `;
 

--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -8,6 +8,8 @@ import {
   useCloseAccount,
   useAccountOpen,
   useToggleWallet,
+  useToggleThemeMode,
+  useThemeMode,
 } from '../../context/AppProvider';
 import { Color, ViewportWidth } from '../../theme';
 import { ReactComponent as LogoSvg } from '../icons/mstable-small.svg';
@@ -59,7 +61,8 @@ const Logo = styled.div<{ inverted?: boolean }>`
 
     path,
     rect {
-      fill: ${({ theme, inverted }) => (inverted ? theme.color.white : 'auto')};
+      fill: ${({ theme, inverted }) =>
+        inverted ? theme.color.white : theme.color.body};
     }
   }
 `;
@@ -88,8 +91,8 @@ const AccountButton = styled(UnstyledButton)<{ active: boolean }>`
     active ? Color.whiteTransparent : 'transparent'};
 
   &:hover {
-    background: ${({ active }) =>
-      active ? Color.whiteTransparent : Color.blackTransparent};
+    background: ${({ active, theme }) =>
+      active ? Color.whiteTransparent : theme.color.bodyTransparent};
   }
 `;
 
@@ -117,7 +120,7 @@ const TruncatedAddress = styled.span`
 `;
 
 const Balance = styled.div`
-  border: 1px solid ${({ theme }) => theme.color.blackTransparent};
+  border: 1px solid ${({ theme }) => theme.color.bodyTransparent};
   padding: 0.33rem 0.75rem;
   font-weight: 600;
   border-radius: 1.5rem;
@@ -142,15 +145,17 @@ const Inner = styled.div`
 `;
 
 const Container = styled.div<{ inverted: boolean }>`
-  background: ${({ inverted }) => (inverted ? Color.black : Color.white)};
+  background: ${({ inverted, theme }) =>
+    inverted ? Color.black : theme.color.background};
   height: 48px;
   display: flex;
   justify-content: center;
   padding-top: 2px;
-  border-bottom: 1px solid ${Color.blackTransparenter};
+  border-bottom: 1px solid ${({ theme }) => theme.color.bodyTransparenter};
 
   ${AccountButton}, ${Balance} {
-    color: ${({ inverted }) => (inverted ? Color.white : Color.offBlack)};
+    color: ${({ inverted, theme }) =>
+      inverted ? Color.white : theme.color.body};
   }
 `;
 
@@ -246,6 +251,8 @@ const WalletButton: FC = () => {
 export const AppBar: FC = () => {
   const accountOpen = useAccountOpen();
   const closeAccount = useCloseAccount();
+  const toggleThemeMode = useToggleThemeMode();
+  const themeMode = useThemeMode();
   const massetState = useSelectedMassetState();
   const massetToken = useTokenSubscription(massetState?.address);
 
@@ -262,6 +269,9 @@ export const AppBar: FC = () => {
               {`${massetToken.symbol}`}
             </Balance>
           )}
+          <UnstyledButton onClick={toggleThemeMode}>
+              {themeMode}
+            </UnstyledButton>
         </Logo>
         <WalletButton />
       </Inner>

--- a/src/components/layout/Background.tsx
+++ b/src/components/layout/Background.tsx
@@ -16,7 +16,7 @@ const Container = styled.div<Props>`
   z-index: -1;
   transition: background-color 0.3s ease;
   background-color: ${({ theme, accountOpen }) =>
-    accountOpen ? theme.color.black : theme.color.white};
+    accountOpen ? theme.color.black : theme.color.background};
 `;
 
 export const Background: FC<Props> = ({ home, accountOpen }) => (

--- a/src/components/layout/BannerMessage.tsx
+++ b/src/components/layout/BannerMessage.tsx
@@ -6,7 +6,7 @@ import { useBannerMessage } from '../../context/AppProvider';
 
 const Container = styled.div`
   display: flex;
-  background: rgba(248, 248, 248, 1);
+  background: ${({ theme }) => theme.color.backgroundAccent};
   margin-bottom: 1rem;
   border-radius: 2rem;
   align-items: center;
@@ -15,7 +15,7 @@ const Container = styled.div`
 
   a {
     border: none;
-    color: ${({ theme }) => theme.color.blue};
+    color: ${({ theme }) => theme.color.primary};
     font-weight: 600;
 
     :hover,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ const Container = styled.header<{ accountOpen: boolean; home: boolean }>`
   align-items: center;
   justify-content: center;
   background: ${({ accountOpen, theme }) =>
-    accountOpen ? theme.color.black : theme.color.white};
+    accountOpen ? theme.color.black : theme.color.background};
 `;
 
 export const Header: FC<{ home: boolean }> = ({ home }) => {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -62,7 +62,7 @@ const GlobalStyle = createGlobalStyle<{ idle: boolean }>`
   }
   body, button, input {
     font-family: 'Poppins', sans-serif;
-    color: ${Color.offBlack};
+    color: ${({ theme }) => theme.color.body};
     line-height: 1.3rem;
   }
   // Onboard.js

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -25,7 +25,7 @@ const Item = styled.li<{
   span {
     white-space: nowrap;
     color: ${({ theme, active }) =>
-      active ? theme.color.blue : theme.color.black};
+      active ? theme.color.primary : theme.color.body};
   }
 
   span {

--- a/src/components/layout/css.ts
+++ b/src/components/layout/css.ts
@@ -3,7 +3,7 @@ import { css } from 'styled-components';
 import { ViewportWidth } from '../../theme';
 
 export const containerBackground = css`
-  border: 4px solid ${({ theme }) => theme.color.lighterGrey};
+  border: 4px solid ${({ theme }) => theme.color.accent};
   padding: 2rem 1rem;
   border-radius: 2rem;
 

--- a/src/components/pages/Save/BalanceRow.tsx
+++ b/src/components/pages/Save/BalanceRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement } from 'react';
+import React, { FC } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import styled, { css } from 'styled-components';
 
@@ -66,7 +66,7 @@ const Number = styled.span`
 `;
 
 const Line = styled.div`
-  background: #eee;
+  background: ${({ theme }) => theme.color.accent};
   height: 2px;
   width: 4rem;
 `;
@@ -75,7 +75,7 @@ const Title = styled.div`
   display: flex;
   font-weight: 600;
   text-align: left;
-  color: ${({ theme }) => theme.color.blue};
+  color: ${({ theme }) => theme.color.primary};
 
   div {
     position: relative;
@@ -119,11 +119,11 @@ const StyledWarningBadge = styled(WarningBadge)`
 `;
 
 const VaultContainer = styled.div`
-  border: 1px #eee solid;
+  border: 1px ${({ theme }) => theme.color.accent} solid;
   border-radius: 0.75rem;
 
   > div {
-    border-top: 1px solid #eee;
+    border-top: 1px solid ${({ theme }) => theme.color.accent};
   }
 `;
 

--- a/src/components/pages/Save/SaveMigration.tsx
+++ b/src/components/pages/Save/SaveMigration.tsx
@@ -32,7 +32,7 @@ const Card = styled.div`
   padding: 1.5rem;
   border-radius: 1.5rem;
   position: relative;
-  background: white;
+  background: ${({ theme }) => theme.color.background};
   display: flex;
   align-items: center;
   flex-direction: column;

--- a/src/components/pages/Save/WeeklySaveAPY.tsx
+++ b/src/components/pages/Save/WeeklySaveAPY.tsx
@@ -21,7 +21,7 @@ const SaveAPYContainer = styled.div`
 const InfoCountUp = styled(CountUp)`
   font-size: 1.5rem;
   font-family: 'DM Mono', monospace;
-  color: ${({ theme }) => theme.color.blue};
+  color: ${({ theme }) => theme.color.primary};
 `;
 
 const InfoMsg = styled.div`

--- a/src/components/pages/Save/v1/index.tsx
+++ b/src/components/pages/Save/v1/index.tsx
@@ -13,7 +13,7 @@ const Container = styled.div`
   gap: 0.75rem;
   border-radius: 0 0 2px 2px;
   text-align: left;
-  border-top: 1px solid #eee;
+  border-top: 1px solid ${({ theme }) => theme.color.accent};
   padding-top: 1rem;
 `;
 

--- a/src/components/pages/Save/v2/Boost.tsx
+++ b/src/components/pages/Save/v2/Boost.tsx
@@ -31,7 +31,7 @@ const StyledButton = styled(UnstyledButton)`
   align-items: center;
   gap: 1rem;
   padding: 0.5rem 1.5rem;
-  background: #eee;
+  background: ${({ theme }) => theme.color.accent};
   color: rgba(121, 121, 121, 1);
   border-radius: 1.5rem;
   font-size: 0.9rem;
@@ -61,7 +61,7 @@ const BoostBarLine = styled.div`
   height: 2px;
   margin-left: 16px;
   margin-right: 16px;
-  background: #eee;
+  background: ${({ theme }) => theme.color.accent};
 `;
 
 const BoostBarRange = styled.div`
@@ -86,7 +86,7 @@ const BoostValue = styled.div`
   justify-content: space-between;
   gap: 1rem;
   padding: 1rem 1.5rem;
-  background: #eee;
+  background: ${({ theme }) => theme.color.accent};
   border-radius: 1rem;
 
   ${BoostCountup} {

--- a/src/components/pages/Save/v2/SavingsReward.tsx
+++ b/src/components/pages/Save/v2/SavingsReward.tsx
@@ -28,7 +28,7 @@ const PreviewText = styled.span`
 `;
 
 const Line = styled.div`
-  background: #eee;
+  background: ${({ theme }) => theme.color.accent};
   height: 2px;
   margin: 0 1.25rem;
   flex: 1;

--- a/src/components/pages/Save/v2/index.tsx
+++ b/src/components/pages/Save/v2/index.tsx
@@ -29,7 +29,7 @@ const Container = styled.div`
   gap: 0.75rem;
   border-radius: 0 0 2px 2px;
   text-align: left;
-  border-top: 1px solid #eee;
+  border-top: 1px solid ${({ theme }) => theme.color.accent};
   padding-top: 1rem;
 `;
 

--- a/src/context/AppProvider.tsx
+++ b/src/context/AppProvider.tsx
@@ -234,7 +234,14 @@ export const AppProvider: FC = ({ children }) => {
             toggleThemeMode,
           },
         ],
-        [state, closeAccount, setBannerMessage, toggleWallet, setThemeMode, toggleThemeMode],
+        [
+          state,
+          closeAccount,
+          setBannerMessage,
+          toggleWallet,
+          setThemeMode,
+          toggleThemeMode,
+        ],
       )}
     >
       {children}

--- a/src/context/AppProvider.tsx
+++ b/src/context/AppProvider.tsx
@@ -22,12 +22,15 @@ export interface BannerMessage {
   visible: boolean;
 }
 
+type ThemeMode = 'light' | 'dark';
+
 enum Actions {
   SupportedChainSelected,
   SetOnline,
   ToggleAccount,
   CloseAccount,
   SetBannerMessage,
+  SetThemeMode,
 }
 
 export enum StatusWarnings {
@@ -41,6 +44,7 @@ interface State {
   accountOpen: boolean;
   online: boolean;
   bannerMessage?: BannerMessage;
+  themeMode: ThemeMode;
 }
 
 type Action =
@@ -48,12 +52,15 @@ type Action =
   | { type: Actions.CloseAccount }
   | { type: Actions.SupportedChainSelected; payload: boolean }
   | { type: Actions.SetOnline; payload: boolean }
+  | { type: Actions.SetThemeMode; payload: ThemeMode | null }
   | { type: Actions.SetBannerMessage; payload?: BannerMessage };
 
 interface Dispatch {
   closeAccount(): void;
   toggleWallet(): void;
   setBannerMessage(message?: BannerMessage): void;
+  setThemeMode(mode: ThemeMode): void;
+  toggleThemeMode(): void;
 }
 
 const reducer: Reducer<State, Action> = (state, action) => {
@@ -73,6 +80,15 @@ const reducer: Reducer<State, Action> = (state, action) => {
       return { ...state, online: action.payload };
     case Actions.SetBannerMessage:
       return { ...state, bannerMessage: action.payload };
+    case Actions.SetThemeMode: {
+      if (action.payload === null) {
+        return {
+          ...state,
+          themeMode: state.themeMode === 'light' ? 'dark' : 'light',
+        };
+      }
+      return { ...state, theme: action.payload ?? 'light' };
+    }
     default:
       return state;
   }
@@ -83,6 +99,7 @@ const initialState: State = {
   supportedChain: true,
   accountOpen: false,
   online: true,
+  themeMode: 'light',
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,6 +125,23 @@ export const AppProvider: FC = ({ children }) => {
     },
     [dispatch],
   );
+
+  const setThemeMode = useCallback<Dispatch['setThemeMode']>(
+    mode => {
+      dispatch({
+        type: Actions.SetThemeMode,
+        payload: mode,
+      });
+    },
+    [dispatch],
+  );
+
+  const toggleThemeMode = useCallback<Dispatch['toggleThemeMode']>(() => {
+    dispatch({
+      type: Actions.SetThemeMode,
+      payload: null,
+    });
+  }, [dispatch]);
 
   const closeAccount = useCallback<Dispatch['closeAccount']>(() => {
     dispatch({ type: Actions.CloseAccount });
@@ -196,9 +230,11 @@ export const AppProvider: FC = ({ children }) => {
             closeAccount,
             setBannerMessage,
             toggleWallet,
+            setThemeMode,
+            toggleThemeMode,
           },
         ],
-        [state, closeAccount, setBannerMessage, toggleWallet],
+        [state, closeAccount, setBannerMessage, toggleWallet, setThemeMode, toggleThemeMode],
       )}
     >
       {children}
@@ -239,3 +275,8 @@ export const useBannerMessage = (): State['bannerMessage'] =>
 
 export const useSetBannerMessage = (): Dispatch['setBannerMessage'] =>
   useAppDispatch().setBannerMessage;
+
+export const useThemeMode = (): State['themeMode'] => useAppState().themeMode;
+
+export const useToggleThemeMode = (): Dispatch['toggleThemeMode'] =>
+  useAppDispatch().toggleThemeMode;

--- a/src/context/ThemeProvider.tsx
+++ b/src/context/ThemeProvider.tsx
@@ -1,11 +1,15 @@
 import React, { FC } from 'react';
 import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components';
 
-import { theme } from '../theme';
+import { lightTheme, darkTheme } from '../theme';
+import { useThemeMode } from './AppProvider';
 
 export const ThemeProvider: FC = ({ children }) => {
+  const themeMode = useThemeMode();
   return (
-    <StyledComponentsThemeProvider theme={theme}>
+    <StyledComponentsThemeProvider
+      theme={themeMode === 'light' ? lightTheme : darkTheme}
+    >
       {children}
     </StyledComponentsThemeProvider>
   );

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -18,25 +18,25 @@ export const Providers: FC = ({ children }) => (
   <NotificationsProvider>
     <ApolloProvider>
       <UserProvider>
-        <ThemeProvider>
-          <BlockProvider>
-            <GasPricesProvider>
-              <TransactionsProvider>
-                <SelectedMassetNameProvider>
-                  <TokensProvider>
-                    <DataProvider>
-                      <AppProvider>
+        <BlockProvider>
+          <GasPricesProvider>
+            <TransactionsProvider>
+              <SelectedMassetNameProvider>
+                <TokensProvider>
+                  <DataProvider>
+                    <AppProvider>
+                      <ThemeProvider>
                         <SelectedSaveVersionProvider>
                           <ModalProvider>{children}</ModalProvider>
                         </SelectedSaveVersionProvider>
-                      </AppProvider>
-                    </DataProvider>
-                  </TokensProvider>
-                </SelectedMassetNameProvider>
-              </TransactionsProvider>
-            </GasPricesProvider>
-          </BlockProvider>
-        </ThemeProvider>
+                      </ThemeProvider>
+                    </AppProvider>
+                  </DataProvider>
+                </TokensProvider>
+              </SelectedMassetNameProvider>
+            </TransactionsProvider>
+          </GasPricesProvider>
+        </BlockProvider>
       </UserProvider>
     </ApolloProvider>
   </NotificationsProvider>

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,10 +1,10 @@
 import 'styled-components';
 
-import { Color, Spacing, Size, FontSize, ViewportWidth, mixins } from './theme';
+import { Color, ColorTheme, Spacing, Size, FontSize, ViewportWidth, mixins } from './theme';
 
 declare module 'styled-components' {
   export interface DefaultTheme {
-    color: typeof Color;
+    color: typeof Color | ColorTheme;
     spacing: typeof Spacing;
     size: typeof Size;
     fontSize: typeof FontSize;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,6 +7,7 @@ export enum Color {
   greenTransparent = 'rgba(82,204,147, 0.2)',
   coolMint = 'rgb(133,242,190)',
   blue = 'rgb(23,110,222)',
+  coolBlue = 'rgb(74,161,255)',
   blueTransparent = 'rgba(0,92,222,0.2)',
   orange = 'rgb(202,94,0)',
   red = 'rgb(202,0,27)',
@@ -15,6 +16,7 @@ export enum Color {
   white = 'rgb(255,255,255)',
   black = 'rgb(0,0,0)',
   whiteTransparent = 'rgba(255,255,255,0.2)',
+  whiteTransparenter = 'rgba(255,255,255,0.1)',
   blackTransparent = 'rgba(0,0,0,0.1)',
   blackTransparenter = 'rgba(0,0,0,0.06)',
   offWhite = 'rgb(249,245,242)',
@@ -23,6 +25,30 @@ export enum Color {
   lighterGrey = 'rgba(248,248,248,1)',
   grey = 'rgba(121, 121, 121, 1)',
   greyTransparent = 'rgba(127, 127, 127, 0.5)',
+}
+
+interface ColorTheme {
+  primary: string;
+  body: string;
+  accent: string;
+  bodyTransparent: string;
+  bodyTransparenter: string;
+  background: string;
+  backgroundAccent: string;
+}
+
+export const colorTheme = (theme: 'light' | 'dark'): ColorTheme => {
+  const isLight = theme === 'light'
+  return ({
+    ...Color,
+    primary: isLight ? Color.blue : Color.coolBlue,
+    body: isLight ? Color.offBlack : Color.offWhite,
+    accent: isLight ? '#eee' : '#222',
+    bodyTransparent: isLight ? Color.blackTransparent : Color.whiteTransparent,
+    bodyTransparenter: isLight ? Color.blackTransparenter : Color.whiteTransparenter,
+    background: isLight ? Color.white : Color.black,
+    backgroundAccent: isLight ? '#f3f3f3' : '#222',
+  })
 }
 
 export enum Size {
@@ -127,11 +153,16 @@ export const mixins = {
   `,
 };
 
-export const theme: DefaultTheme = {
-  color: Color,
+export const lightTheme: DefaultTheme = {
+  color: colorTheme('light'),
   spacing: Spacing,
   size: Size,
   fontSize: FontSize,
   viewportWidth: ViewportWidth,
   mixins,
+};
+
+export const darkTheme: DefaultTheme = {
+  ...lightTheme,
+  color: colorTheme('dark'),
 };


### PR DESCRIPTION
## Adds:
- Basic outline for darkmode

**A fair bit is missing (note svgs, etc) but shouldn't take long to transition the rest**

## Screenshots
|  Desktop 
| --- | 
| <img width="1680" alt="Screenshot 2021-01-13 at 09 28 09" src="https://user-images.githubusercontent.com/19643324/104433697-4fed6700-5582-11eb-980b-f283bf77673b.png"> |

