### PR TITLE
Home page colour updates

### DIFF
--- a/src/components/core/MassetSelector.tsx
+++ b/src/components/core/MassetSelector.tsx
@@ -37,8 +37,8 @@ const OptionContainer = styled(UnstyledButton)<{
 }>`
   display: flex;
   width: 100%;
-  border: ${({ theme, selected }) =>
-    selected ? `1px solid ${theme.color.accent}` : `none`};
+  background: ${({ theme, selected, active }) =>
+    selected && active ? `${theme.color.accent}` : `none`};
   text-align: left;
   padding: 0.25rem 0.5rem;
   align-items: center;

--- a/src/components/pages/index.tsx
+++ b/src/components/pages/index.tsx
@@ -28,23 +28,17 @@ const StyledButton = styled(UnstyledButton)<{ asset: MassetName }>`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: ${({ theme }) =>
-    theme.isLight ? theme.color.offBlack : 'transparent'};
-  border: 4px solid
-    ${({ theme, asset }) =>
-      asset === 'musd' ? theme.color.blueAccent : theme.color.goldAccent};
   border-radius: 2rem;
   padding: 2rem 0;
   font-weight: bold;
-  color: white;
+  background: ${({ theme }) => theme.color.backgroundAccent};
 
   > *:not(:last-child) {
     margin-bottom: 2rem;
   }
 
   &:hover {
-    background: ${({ theme }) =>
-      theme.isLight ? theme.color.offBlackAccent : theme.color.accent};
+    background: ${({ theme }) => theme.color.accentContrast};
   }
 
   &:active {
@@ -100,10 +94,10 @@ const Buttons = styled.div`
 `;
 
 const Tagline = styled.h1`
-  font-size: 2rem;
+  font-size: 1.5rem;
   line-height: 3rem;
   text-align: center;
-  color: ${({ theme }) => theme.color.accentContrast};
+  color: ${({ theme }) => theme.color.bodyAccent};
   text-transform: lowercase;
   padding: 0 1rem;
 `;
@@ -150,7 +144,9 @@ export const Home: FC = () => {
     <Container>
       <Header>
         <Logo />
-        <Tagline>Unite assets into one standard</Tagline>
+        <Tagline>
+          Autonomous and non-custodial stablecoin infrastructure.
+        </Tagline>
       </Header>
       <Buttons>
         <MassetButton massetName="mbtc" />

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,14 +2,10 @@ import { DefaultTheme, css } from 'styled-components';
 
 export enum Color {
   gold = 'rgb(255,179,52)',
-  lightGold = 'rgb(255,237,209)',
-  darkGold = 'rgb(123,104,56)',
   green = 'rgb(82,204,147)',
   greenTransparent = 'rgba(82,204,147, 0.2)',
   coolMint = 'rgb(133,242,190)',
   blue = 'rgb(23,110,222)',
-  lightBlue = 'rgb(227,239,255)',
-  darkBlue = 'rgb(99,128,166)',
   coolBlue = 'rgb(74,161,255)',
   coolBlueTransparent = 'rgb(74,161,255, 0.2)',
   blueTransparent = 'rgba(0,92,222,0.2)',
@@ -43,8 +39,6 @@ interface ColorTheme {
   bodyTransparenter: string;
   background: string;
   backgroundAccent: string;
-  blueAccent: string;
-  goldAccent: string;
 }
 
 export const colorTheme = (theme: 'light' | 'dark'): ColorTheme => {
@@ -65,8 +59,6 @@ export const colorTheme = (theme: 'light' | 'dark'): ColorTheme => {
       : Color.whiteTransparenter,
     background: isLight ? Color.white : Color.black,
     backgroundAccent: isLight ? '#f3f3f3' : '#222',
-    blueAccent: isLight ? Color.lightBlue : Color.darkBlue,
-    goldAccent: isLight ? Color.lightGold : Color.darkGold,
   };
 };
 


### PR DESCRIPTION
## Adds:
- Removes border, sets background to grey
- Removes border on massetselector component (AppBar)
- Updates tagline

|  Home update
| --- | 
| <img width="988" alt="Screenshot 2021-01-29 at 16 42 55" src="https://user-images.githubusercontent.com/19643324/106302635-20607f00-6251-11eb-978c-7caa4802dfb9.png"> | 

|  Masset update
| --- | 
| <img width="616" alt="Screenshot 2021-01-29 at 16 43 03" src="https://user-images.githubusercontent.com/19643324/106302682-2b1b1400-6251-11eb-80d8-b25b94df9bda.png"> | 

