### PR TITLE
Use correct SaveWrapper constant

### DIFF
--- a/src/components/core/MassetSelector.tsx
+++ b/src/components/core/MassetSelector.tsx
@@ -18,7 +18,7 @@ export const MassetSelector: FC = () => {
         mbtc: dataState.mbtc,
         musd: dataState.musd,
       } as { [key in MassetName]: MassetState | undefined }),
-    [dataState.mbtc, dataState.musd],
+    [dataState],
   );
 
   const options = Object.values(massetStates).map(massetState => ({

--- a/src/components/core/Toggle.tsx
+++ b/src/components/core/Toggle.tsx
@@ -33,7 +33,7 @@ export const Toggle: FC<Props> = ({ className, options }) => {
             onClick={onClick}
             type="button"
             highlighted={active}
-            scale={0.9}
+            scale={0.875}
           >
             {title}
           </Button>

--- a/src/components/layout/css.ts
+++ b/src/components/layout/css.ts
@@ -8,6 +8,6 @@ export const containerBackground = css`
   border-radius: 2rem;
 
   @media (min-width: ${ViewportWidth.s}) {
-    padding: 2rem 2.5rem;
+    padding: 2rem;
   }
 `;

--- a/src/components/pages/Earn/Pool/CurveAddLiquidity.tsx
+++ b/src/components/pages/Earn/Pool/CurveAddLiquidity.tsx
@@ -133,7 +133,7 @@ export const CurveAddLiquidity: FC = () => {
         );
       }
     },
-    [valid, amount, curveContracts.musdDeposit, token],
+    [valid, amount, curveContracts, token],
   );
 
   return expired ? (

--- a/src/components/pages/Earn/index.tsx
+++ b/src/components/pages/Earn/index.tsx
@@ -383,7 +383,7 @@ const EarnContent: FC = () => {
                 action={PageAction.Earn}
                 subtitle="Ecosystem rewards with mStable"
               >
-                <Button onClick={toggleOnboardingVisible}>
+                <Button onClick={toggleOnboardingVisible} scale={0.875}>
                   View introduction
                 </Button>
               </PageHeader>

--- a/src/components/pages/MassetPage.tsx
+++ b/src/components/pages/MassetPage.tsx
@@ -48,7 +48,7 @@ const Container = styled.div`
   @media (min-width: ${({ theme }) => theme.viewportWidth.m}) {
     display: flex;
     flex-direction: row;
-    gap: 1rem;
+    gap: 2rem;
     justify-content: space-between;
     align-items: flex-start;
 

--- a/src/components/pages/PageHeader.tsx
+++ b/src/components/pages/PageHeader.tsx
@@ -70,6 +70,7 @@ const Container = styled.div`
   p {
     padding: 0;
     font-size: 1rem;
+    color: ${({ theme }) => theme.color.bodyAccent};
   }
 `;
 

--- a/src/components/pages/Save/v2/MassetModal.tsx
+++ b/src/components/pages/Save/v2/MassetModal.tsx
@@ -17,10 +17,6 @@ import { TabBtn, TabsContainer, Message } from '../../../core/Tabs';
 import { AssetExchange } from '../../../forms/AssetExchange';
 import { SendButton } from '../../../forms/SendButton';
 import { BigDecimal } from '../../../../web3/BigDecimal';
-import {
-  formatMassetName,
-  useSelectedMassetName,
-} from '../../../../context/SelectedMassetNameProvider';
 
 const formId = 'MassetModal';
 
@@ -35,7 +31,6 @@ export const MassetModal: FC = () => {
   const propose = usePropose();
 
   const massetState = useSelectedMassetState();
-  const massetName = useSelectedMassetName();
   const massetAddress = massetState?.address;
   const massetSymbol = massetState?.token.symbol;
   const savingsContract = massetState?.savingsContracts.v2;
@@ -48,7 +43,8 @@ export const MassetModal: FC = () => {
 
   const inputToken = useTokenSubscription(inputAddress);
 
-  const formattedMassetName = formatMassetName(massetName);
+  const saveWrapperAddress =
+    ADDRESSES[massetSymbol as 'mBTC' | 'mUSD']?.SaveWrapper;
 
   const error = useMemo<string | undefined>(() => {
     if (
@@ -87,11 +83,11 @@ export const MassetModal: FC = () => {
 
   const stakeApprove = useMemo(
     () => ({
-      spender: ADDRESSES.mUSD.SaveWrapper as string,
+      spender: saveWrapperAddress as string,
       amount: inputAmount,
       address: massetAddress as string,
     }),
-    [inputAmount, massetAddress],
+    [inputAmount, massetAddress, saveWrapperAddress],
   );
 
   const valid = !!(
@@ -104,18 +100,18 @@ export const MassetModal: FC = () => {
   return (
     <Container>
       <TabsContainer>
-        <TabBtn active>Deposit {formattedMassetName}</TabBtn>
+        <TabBtn active>Deposit {massetSymbol}</TabBtn>
       </TabsContainer>
       <Message>
         <span>
-          {formattedMassetName} will be deposited and you will receive{' '}
-          {`i${formattedMassetName}`} (interest-bearing
-          {` ${formattedMassetName}`}).
+          {massetSymbol} will be deposited and you will receive{' '}
+          {`i${massetSymbol}`} (interest-bearing
+          {` ${massetSymbol}`}).
           <br />
           Deposit to the Vault to earn bonus MTA rewards.
           <br />
-          Your {`i${formattedMassetName}`} can be redeemed for{' '}
-          {formattedMassetName} at any time.
+          Your {`i${massetSymbol}`} can be redeemed for {massetSymbol} at any
+          time.
         </span>
       </Message>
       <AssetExchange
@@ -137,7 +133,7 @@ export const MassetModal: FC = () => {
       >
         <SendButton
           valid={valid}
-          title={`Mint i${formattedMassetName}`}
+          title={`Mint i${massetSymbol}`}
           handleSend={() => {
             if (saveAddress && signer && inputAmount && massetSymbol) {
               const body = `${inputAmount.format()} ${massetSymbol}`;
@@ -157,7 +153,7 @@ export const MassetModal: FC = () => {
           }}
           approve={depositApprove}
         />
-        {ADDRESSES.mUSD.SaveWrapper && (
+        {saveWrapperAddress && (
           <SendButton
             valid={valid}
             title="Mint & Deposit to Vault"
@@ -167,7 +163,7 @@ export const MassetModal: FC = () => {
                 propose<Interfaces.SaveWrapper, 'saveAndStake'>(
                   new TransactionManifest(
                     SaveWrapperFactory.connect(
-                      ADDRESSES.mUSD.SaveWrapper as string,
+                      saveWrapperAddress as string,
                       signer,
                     ),
                     'saveAndStake',

--- a/src/components/pages/Save/v2/SaveDeposit.tsx
+++ b/src/components/pages/Save/v2/SaveDeposit.tsx
@@ -39,13 +39,16 @@ export const SaveDeposit: FC<{
   const massetState = useSelectedMassetState();
   const massetAddress = massetState?.address;
   const savingsContract = massetState?.savingsContracts.v2;
+  const massetSymbol = massetState?.token.symbol;
   const vault = savingsContract?.boostedSavingsVault;
   const vaultAddress = vault?.address;
   const vaultBalance = vault?.account?.rawBalance ?? BigDecimal.ZERO;
   const saveExchangeRate = savingsContract?.latestExchangeRate?.rate;
   const saveAddress = savingsContract?.address;
+  const saveWrapperAddress =
+    ADDRESSES[massetSymbol as 'mBTC' | 'mUSD']?.SaveWrapper;
   const canDepositWithWrapper = !!(
-    savingsContract?.active && !!ADDRESSES.mUSD.SaveWrapper
+    savingsContract?.active && !!saveWrapperAddress
   );
 
   const bassets = useMemo(
@@ -112,23 +115,35 @@ export const SaveDeposit: FC<{
   const depositApprove = useMemo(
     () => ({
       spender: isDepositingBasset
-        ? (ADDRESSES.mUSD.SaveWrapper as string)
+        ? (saveWrapperAddress as string)
         : (saveAddress as string),
       amount: scaledInputAmount,
       address: inputAddress as string,
     }),
-    [isDepositingBasset, saveAddress, scaledInputAmount, inputAddress],
+    [
+      isDepositingBasset,
+      saveWrapperAddress,
+      saveAddress,
+      scaledInputAmount,
+      inputAddress,
+    ],
   );
 
   const stakeApprove = useMemo(
     () => ({
       spender: isDepositingSave
         ? (vaultAddress as string)
-        : (ADDRESSES.mUSD.SaveWrapper as string),
+        : (saveWrapperAddress as string),
       amount: scaledInputAmount,
       address: inputAddress as string,
     }),
-    [scaledInputAmount, inputAddress, isDepositingSave, vaultAddress],
+    [
+      isDepositingSave,
+      vaultAddress,
+      saveWrapperAddress,
+      scaledInputAmount,
+      inputAddress,
+    ],
   );
 
   const valid = !!(!error && inputAmount && inputAmount.simple > 0);
@@ -219,7 +234,7 @@ export const SaveDeposit: FC<{
                     return propose<Interfaces.SaveWrapper, 'saveViaMint'>(
                       new TransactionManifest(
                         SaveWrapperFactory.connect(
-                          ADDRESSES.mUSD.SaveWrapper as string,
+                          saveWrapperAddress as string,
                           signer,
                         ),
                         'saveViaMint',
@@ -253,7 +268,7 @@ export const SaveDeposit: FC<{
                     return propose<Interfaces.SaveWrapper, 'saveAndStake'>(
                       new TransactionManifest(
                         SaveWrapperFactory.connect(
-                          ADDRESSES.mUSD.SaveWrapper as string,
+                          saveWrapperAddress as string,
                           signer,
                         ),
                         'saveAndStake',
@@ -268,7 +283,7 @@ export const SaveDeposit: FC<{
                     return propose<Interfaces.SaveWrapper, 'saveViaMint'>(
                       new TransactionManifest(
                         SaveWrapperFactory.connect(
-                          ADDRESSES.mUSD.SaveWrapper as string,
+                          saveWrapperAddress as string,
                           signer,
                         ),
                         'saveViaMint',

--- a/src/components/pages/Save/v2/SaveDepositETH.tsx
+++ b/src/components/pages/Save/v2/SaveDepositETH.tsx
@@ -98,9 +98,12 @@ export const SaveDepositETH: FC<{
 
   const massetState = useSelectedMassetState();
   const massetAddress = massetState?.address;
+  const massetSymbol = massetState?.token.symbol;
   const savingsContract = massetState?.savingsContracts.v2;
   const saveExchangeRate = savingsContract?.latestExchangeRate?.rate;
   const saveAddress = savingsContract?.address;
+  const saveWrapperAddress =
+    ADDRESSES[massetSymbol as 'mBTC' | 'mUSD']?.SaveWrapper;
 
   const [inputAmount, inputFormValue, setInputFormValue] = useBigDecimalInput();
   const [uniswapAmountOut, setUniswapAmountOut] = useState<{
@@ -240,7 +243,7 @@ export const SaveDepositETH: FC<{
                 propose<Interfaces.SaveWrapper, 'saveViaUniswapETH'>(
                   new TransactionManifest(
                     SaveWrapperFactory.connect(
-                      ADDRESSES.mUSD.SaveWrapper as string,
+                      saveWrapperAddress as string,
                       signer,
                     ),
                     'saveViaUniswapETH',
@@ -291,7 +294,7 @@ export const SaveDepositETH: FC<{
               propose<Interfaces.SaveWrapper, 'saveViaUniswapETH'>(
                 new TransactionManifest(
                   SaveWrapperFactory.connect(
-                    ADDRESSES.mUSD.SaveWrapper as string,
+                    saveWrapperAddress as string,
                     signer,
                   ),
                   'saveViaUniswapETH',

--- a/src/components/pages/Save/v2/SaveModal.tsx
+++ b/src/components/pages/Save/v2/SaveModal.tsx
@@ -7,10 +7,6 @@ import { SaveDepositETH } from './SaveDepositETH';
 import { SaveRedeem } from './SaveRedeem';
 import { useSelectedMassetState } from '../../../../context/DataProvider/DataProvider';
 import { ADDRESSES } from '../../../../constants';
-import {
-  formatMassetName,
-  useSelectedMassetName,
-} from '../../../../context/SelectedMassetNameProvider';
 
 enum Tabs {
   DepositStablecoins,
@@ -37,23 +33,26 @@ const tabInfo = (
 // TODO TabbedModal
 export const SaveModal: FC = () => {
   const massetState = useSelectedMassetState();
-  const massetName = useSelectedMassetName();
+  const massetSymbol = massetState?.token.symbol;
   const isActive = massetState?.savingsContracts.v2?.active;
+  const saveWrapperAddress =
+    ADDRESSES[massetSymbol as 'mBTC' | 'mUSD']?.SaveWrapper;
 
   const [tab, setTab] = useState<Tabs>(Tabs.DepositStablecoins);
 
-  const formattedMassetName = formatMassetName(massetName);
-  const tabInfoMessage = tabInfo(formattedMassetName)[tab];
+  const tabInfoMessage = massetSymbol && tabInfo(massetSymbol)[tab];
 
   const [tabs, ActiveComponent] = useMemo(() => {
     const _tabs = [
       {
         tab: Tabs.DepositStablecoins,
-        label: 'Deposit via Stablecoin',
+        label: `Deposit via ${
+          massetSymbol === 'mUSD' ? 'Stablecoin' : 'Stable Asset'
+        }`,
         component: SaveDeposit,
         active: tab === Tabs.DepositStablecoins,
       },
-      ...(isActive && ADDRESSES.mUSD.SaveWrapper
+      ...(isActive && saveWrapperAddress
         ? [
             {
               tab: Tabs.DepositETH,
@@ -65,14 +64,14 @@ export const SaveModal: FC = () => {
         : []),
       {
         tab: Tabs.Redeem,
-        label: 'Redeem mUSD',
+        label: `Redeem ${massetSymbol}`,
         component: SaveRedeem,
         active: tab === Tabs.Redeem,
       },
     ];
     const activeComponent = _tabs.find(t => t.active)?.component as FC;
     return [_tabs, activeComponent];
-  }, [tab, isActive]);
+  }, [tab, isActive, saveWrapperAddress, massetSymbol]);
 
   return (
     <Container>

--- a/src/components/pages/Save/v2/SaveRedeem.tsx
+++ b/src/components/pages/Save/v2/SaveRedeem.tsx
@@ -22,6 +22,7 @@ export const SaveRedeem: FC = () => {
 
   const massetState = useSelectedMassetState();
   const massetAddress = massetState?.address;
+  const massetSymbol = massetState?.token.symbol;
   const savingsContract = massetState?.savingsContracts.v2;
   const saveExchangeRate = savingsContract?.latestExchangeRate?.rate;
   const saveAddress = savingsContract?.address;
@@ -77,7 +78,7 @@ export const SaveRedeem: FC = () => {
     >
       <SendButton
         valid={valid}
-        title="Redeem mUSD"
+        title={`Redeem ${massetSymbol}`}
         handleSend={() => {
           if (
             signer &&

--- a/src/components/pages/Save/v2/VaultModal.tsx
+++ b/src/components/pages/Save/v2/VaultModal.tsx
@@ -8,10 +8,6 @@ import { VaultWithdraw } from './VaultWithdraw';
 import { VaultExit } from './VaultExit';
 import { useSelectedMassetState } from '../../../../context/DataProvider/DataProvider';
 import { ADDRESSES } from '../../../../constants';
-import {
-  formatMassetName,
-  useSelectedMassetName,
-} from '../../../../context/SelectedMassetNameProvider';
 
 enum Tabs {
   Deposit = 'Deposit',
@@ -28,12 +24,14 @@ const Container = styled.div`
   }
 `;
 
-const tabTitles: { [key in Tabs]: string } = {
-  [Deposit]: 'Deposit via Stablecoin',
+const tabTitles = (massetSymbol?: string): { [key in Tabs]: string } => ({
+  [Deposit]: `Deposit via ${
+    massetSymbol === 'mUSD' ? 'Stablecoin' : 'Stable Asset'
+  }`,
   [DepositETH]: 'Deposit via ETH',
   [Withdraw]: 'Withdraw',
   [Exit]: 'Exit',
-};
+});
 
 const tabInfo = (
   formattedMasset: string,
@@ -46,11 +44,13 @@ const tabInfo = (
 
 export const VaultModal: FC = () => {
   const massetState = useSelectedMassetState();
-  const massetName = useSelectedMassetName();
   const [tab, setTab] = useState<Tabs>(Tabs.Deposit);
+  const massetSymbol = massetState?.token.symbol;
+  const saveWrapperAddress =
+    ADDRESSES[massetSymbol as 'mBTC' | 'mUSD']?.SaveWrapper;
 
   const canDepositWithWrapper =
-    massetState?.savingsContracts.v2?.active && !!ADDRESSES.mUSD.SaveWrapper;
+    massetState?.savingsContracts.v2?.active && !!saveWrapperAddress;
 
   const tabs = [
     Withdraw,
@@ -59,8 +59,7 @@ export const VaultModal: FC = () => {
     Exit,
   ];
 
-  const formattedMassetName = formatMassetName(massetName);
-  const tabInfoMessage = tabInfo(formattedMassetName)[tab];
+  const tabInfoMessage = massetSymbol && tabInfo(massetSymbol)[tab];
 
   return (
     <Container>
@@ -69,7 +68,7 @@ export const VaultModal: FC = () => {
           t =>
             t && (
               <TabBtn active={tab === t} onClick={() => setTab(t)} key={t}>
-                {tabTitles[t]}
+                {tabTitles(massetSymbol)[t]}
               </TabBtn>
             ),
         )}

--- a/src/components/pages/Save/v2/index.tsx
+++ b/src/components/pages/Save/v2/index.tsx
@@ -55,7 +55,6 @@ const Container = styled.div`
   }
 `;
 
-// TODO replace masset-specific names/icons
 export const Save: FC = () => {
   const [isCalculatorVisible, setCalculatorVisible] = useState(false);
   const massetState = useSelectedMassetState();

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -24,8 +24,8 @@ export enum Color {
   offBlack = 'rgb(37,39,45)',
   lightGrey = 'rgba(235, 235, 235, 1)',
   lighterGrey = 'rgba(248,248,248,1)',
-  grey = 'rgba(121, 121, 121, 1)',
-  greyTransparent = 'rgba(127, 127, 127, 0.5)',
+  grey = 'rgba(146, 154, 162, 1)',
+  greyTransparent = 'rgba(146, 154, 162, 0.5)',
 }
 
 interface ColorTheme {


### PR DESCRIPTION
## Changelog:
- Replace cases of `ADDRESSES.mUSD` -> `ADDRESSES[symbol as 'mBTC' | 'mUSD'].SaveWrapper`
- Adjusts title of `Deposit Stablecoin` -> `Deposit Stable Asset` for mBTC
- Slight UI tweaks (minor)