### PR TITLE
Fix Max input

### DIFF
--- a/src/hooks/useBigDecimalInput.ts
+++ b/src/hooks/useBigDecimalInput.ts
@@ -30,7 +30,7 @@ export const useBigDecimalInput = (
   );
 
   const [formValue, setFormValue] = useState<string | undefined>(
-    value?.simple !== 0 ? value?.format(2, false) : undefined,
+    value?.simple !== 0 ? value?.string : undefined,
   );
 
   const onChange = useCallback(

--- a/src/hooks/useBigDecimalInputs.ts
+++ b/src/hooks/useBigDecimalInputs.ts
@@ -65,7 +65,7 @@ const setAmount = (
   ...value,
   amount,
   touched: !!(amount?.simple && amount.simple > 0),
-  formValue: amount?.simple !== 0 ? amount?.format(2, false) : undefined,
+  formValue: amount?.simple !== 0 ? amount?.string : undefined,
 });
 
 const reducer: Reducer<State, Action> = (
@@ -92,7 +92,7 @@ const initialise = (initialiserArg: UseBigDecimalInputsArg): State => {
             address,
             decimals,
             amount,
-            formValue: amount?.format(2, false),
+            formValue: amount?.string,
           },
         ];
       },


### PR DESCRIPTION
Changes `.format(2, false)` -> `.string` so when there are low balances `0.0002` they don't clip to `0.00`