### PR TITLE
Earn masset page

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -24,7 +24,6 @@ const Main = styled.main<{ marginTop?: boolean }>`
 `;
 
 const BackgroundContainer = styled.div`
-  min-height: 70vh;
   ${containerBackground}
 `;
 
@@ -206,7 +205,6 @@ export const Layout: FC = ({ children }) => {
   const accountOpen = useAccountOpen();
   const { pathname } = useLocation();
   const home = pathname === '/';
-  const earn = pathname === '/earn';
 
   useLayoutEffect(() => {
     // Scroll to the top when the account view is toggled
@@ -220,8 +218,6 @@ export const Layout: FC = ({ children }) => {
       <Container>
         {accountOpen ? (
           <Account />
-        ) : earn ? (
-          <>{children}</>
         ) : (
           <Main marginTop={home}>
             {!home && <BannerMessage />}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -25,6 +25,7 @@ const Main = styled.main<{ marginTop?: boolean }>`
 
 const BackgroundContainer = styled.div`
   ${containerBackground}
+  min-height: 50vh;
 `;
 
 const GlobalStyle = createGlobalStyle`

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -9,7 +9,6 @@ import { Color } from '../../theme';
 interface NavItem {
   title: string;
   path: string;
-  masset?: boolean;
 }
 
 const List = styled.div`
@@ -17,11 +16,11 @@ const List = styled.div`
 `;
 
 const navItems: NavItem[] = [
-  { title: 'Mint', path: '/mint', masset: true },
-  { title: 'Save', path: '/save', masset: true },
+  { title: 'Mint', path: '/mint' },
+  { title: 'Save', path: '/save' },
   { title: 'Earn', path: '/earn' },
-  { title: 'Swap', path: '/swap', masset: true },
-  { title: 'Redeem', path: '/redeem', masset: true },
+  { title: 'Swap', path: '/swap' },
+  { title: 'Redeem', path: '/redeem' },
 ];
 
 const StyledNavLink = styled(NavLink)`
@@ -41,12 +40,12 @@ export const Navigation: FC = () => {
   return (
     <nav>
       <List>
-        {navItems.map(({ title, path, masset }) => (
+        {navItems.map(({ title, path }) => (
           <StyledNavLink
             activeStyle={{ color: Color.blue }}
             key={title}
             onClick={collapseWallet}
-            to={masset ? `/${massetName}${path}` : path}
+            to={`/${massetName}${path}`}
           >
             {title}
           </StyledNavLink>

--- a/src/components/pages/Earn/Pool/PoolBalances.tsx
+++ b/src/components/pages/Earn/Pool/PoolBalances.tsx
@@ -15,6 +15,7 @@ import { ViewAs } from './ViewAs';
 import { P } from '../../../core/Typography';
 import { Protip } from '../../../core/Protip';
 import { ThemedSkeleton } from '../../../core/ThemedSkeleton';
+import { useSelectedMassetName } from '../../../../context/SelectedMassetNameProvider';
 
 interface Props {
   className?: string;
@@ -86,6 +87,7 @@ export const PoolBalances: FC<Props> = () => {
   const rewardsToken = useCurrentRewardsToken();
   const stakingToken = useCurrentStakingToken();
   const platformToken = useCurrentPlatformToken();
+  const massetName = useSelectedMassetName();
 
   return (
     <div>
@@ -118,7 +120,7 @@ export const PoolBalances: FC<Props> = () => {
                     <StyledProtip emoji="💰" title="Claim BAL">
                       <P>
                         You can now claim any BAL earned directly from the{' '}
-                        <Link to="/earn">EARN dashboard.</Link>
+                        <Link to={`/${massetName}/earn`}>EARN dashboard.</Link>
                       </P>
                     </StyledProtip>
                   </ProtipContainer>

--- a/src/components/pages/Earn/Pool/PoolContent.tsx
+++ b/src/components/pages/Earn/Pool/PoolContent.tsx
@@ -7,6 +7,7 @@ import { PoolForms } from './PoolForms';
 import { PoolBalances } from './PoolBalances';
 import { ImpermanentLossWarning } from './ImpermanentLossWarning';
 import { useIsMasquerading } from '../../../../context/UserProvider';
+import { useSelectedMassetName } from '../../../../context/SelectedMassetNameProvider';
 
 const BackLink = styled(ButtonLink)`
   display: inline-block;
@@ -33,9 +34,10 @@ const StyledCard = styled(Card)`
 
 export const PoolContent: FC<{ address: string }> = ({ address }) => {
   const isMasquerading = useIsMasquerading();
+  const massetName = useSelectedMassetName();
   return (
     <Container>
-      <BackLink to="/earn">Back</BackLink>
+      <BackLink to={`/${massetName}/earn`}>Back</BackLink>
       <CardContainer>
         <StyledCard address={address} />
       </CardContainer>

--- a/src/components/pages/Earn/Pool/ViewAs.tsx
+++ b/src/components/pages/Earn/Pool/ViewAs.tsx
@@ -12,6 +12,7 @@ import { EtherscanLink } from '../../../core/EtherscanLink';
 import { Button } from '../../../core/Button';
 import { AddressInput } from './AddressInput';
 import { useCurrentStakingRewardsContract } from '../StakingRewardsContractProvider';
+import { useSelectedMassetName } from '../../../../context/SelectedMassetNameProvider';
 
 const Input = styled.div`
   display: flex;
@@ -50,6 +51,7 @@ export const ViewAs: FC<{}> = () => {
   const { pathname } = useLocation();
   const history = useHistory();
   const [address, setAddress] = useState<string | undefined>();
+  const massetName = useSelectedMassetName();
 
   const earnUrl = stakingRewards?.earnUrl;
 
@@ -74,9 +76,9 @@ export const ViewAs: FC<{}> = () => {
 
   const handleShare = useCallback(() => {
     if (earnUrl && account) {
-      copy(`${window.location.host}${earnUrl}/${account}`);
+      copy(`${window.location.host}/${massetName}${earnUrl}/${account}`);
     }
-  }, [account, copy, earnUrl]);
+  }, [account, copy, earnUrl, massetName]);
 
   return (
     <Container>

--- a/src/components/pages/Earn/PoolsOverview.tsx
+++ b/src/components/pages/Earn/PoolsOverview.tsx
@@ -15,6 +15,7 @@ import { AccentColors, Platforms } from '../../../types';
 import { Tooltip } from '../../core/ReactTooltip';
 import { ThemedSkeleton } from '../../core/ThemedSkeleton';
 import { useSelectedMassetName } from '../../../context/SelectedMassetNameProvider';
+import { ADDRESSES } from '../../../constants';
 
 const ApyAmount = styled(Amount)`
   font-size: ${FontSize.m};
@@ -116,7 +117,8 @@ export const PoolsOverview: FC<{}> = () => {
       .filter(item =>
         item.pool.tokens.find(
           token =>
-            token.symbol === 'MTA' || token.symbol.toLowerCase() === massetName,
+            token.address === ADDRESSES.MTA ||
+            token.symbol.toLowerCase() === massetName,
         ),
       )
       .sort((a, b) =>

--- a/src/components/pages/Earn/PoolsOverview.tsx
+++ b/src/components/pages/Earn/PoolsOverview.tsx
@@ -14,6 +14,7 @@ import { ExternalLink } from '../../core/ExternalLink';
 import { AccentColors, Platforms } from '../../../types';
 import { Tooltip } from '../../core/ReactTooltip';
 import { ThemedSkeleton } from '../../core/ThemedSkeleton';
+import { useSelectedMassetName } from '../../../context/SelectedMassetNameProvider';
 
 const ApyAmount = styled(Amount)`
   font-size: ${FontSize.m};
@@ -108,9 +109,16 @@ const platformOrder: { [key in Platforms]: number } = {
 
 export const PoolsOverview: FC<{}> = () => {
   const stakingRewardsContracts = useStakingRewardsContracts();
+  const massetName = useSelectedMassetName();
 
   const [activePools, otherPools, expiredPools] = useMemo(() => {
     const items = Object.values(stakingRewardsContracts)
+      .filter(item =>
+        item.pool.tokens.find(
+          token =>
+            token.symbol === 'MTA' || token.symbol.toLowerCase() === massetName,
+        ),
+      )
       .sort((a, b) =>
         platformOrder[a.pool.platform] < platformOrder[b.pool.platform]
           ? -1 // *teleports behind you*
@@ -263,7 +271,7 @@ export const PoolsOverview: FC<{}> = () => {
           },
           {
             id,
-            url: earnUrl,
+            url: earnUrl.substring(1), // remove leading '/'
             colors,
             data: {},
             hasStaked: false,
@@ -276,7 +284,7 @@ export const PoolsOverview: FC<{}> = () => {
       items.filter(item => !item.expired && !item.hasStaked),
       items.filter(item => item.expired),
     ];
-  }, [stakingRewardsContracts]);
+  }, [massetName, stakingRewardsContracts]);
 
   return (
     <Container>

--- a/src/components/pages/Earn/index.tsx
+++ b/src/components/pages/Earn/index.tsx
@@ -14,7 +14,6 @@ import { Button } from '../../core/Button';
 import { ExternalLink } from '../../core/ExternalLink';
 import { Color, FontSize, ViewportWidth } from '../../../theme';
 import { LocalStorage } from '../../../localStorage';
-import { containerBackground } from '../../layout/css';
 import { PageAction, PageHeader } from '../PageHeader';
 import { PoolsOverview } from './PoolsOverview';
 import { Card } from './Card';
@@ -306,12 +305,15 @@ const SliderContainer = styled.div`
   flex-direction: column;
   width: 100%;
   height: 100%;
+  border-radius: 1rem;
   background: linear-gradient(to top right, #040a10, #131212);
   flex: 1;
   > * {
     flex: 1;
   }
-  margin-top: 20px;
+  > div > div {
+    position: relative;
+  }
 `;
 
 const PageHeaderContainer = styled.div`
@@ -328,7 +330,6 @@ const PageHeaderContainer = styled.div`
 
 const Content = styled.div`
   width: 100%;
-  padding: 0 1rem;
 `;
 
 const Container = styled.div`
@@ -338,10 +339,6 @@ const Container = styled.div`
   flex: 1;
   width: 100%;
   height: 100%;
-`;
-
-const BackgroundContainer = styled.div`
-  ${containerBackground}
 `;
 
 const EarnSlider: FC<{
@@ -377,20 +374,18 @@ const EarnContent: FC = () => {
         </SwipeDisabledProvider>
       ) : (
         <Content>
-          <BackgroundContainer>
-            <PageHeaderContainer>
-              <PageHeader
-                action={PageAction.Earn}
-                subtitle="Ecosystem rewards with mStable"
-              >
-                <Button onClick={toggleOnboardingVisible} scale={0.875}>
-                  View introduction
-                </Button>
-              </PageHeader>
-              <MerkleDropClaims />
-            </PageHeaderContainer>
-            <PoolsOverview />
-          </BackgroundContainer>
+          <PageHeaderContainer>
+            <PageHeader
+              action={PageAction.Earn}
+              subtitle="Ecosystem rewards with mStable"
+            >
+              <Button onClick={toggleOnboardingVisible} scale={0.875}>
+                View introduction
+              </Button>
+            </PageHeader>
+            <MerkleDropClaims />
+          </PageHeaderContainer>
+          <PoolsOverview />
         </Content>
       )}
     </Container>

--- a/src/components/pages/Save/v2/index.tsx
+++ b/src/components/pages/Save/v2/index.tsx
@@ -21,7 +21,6 @@ import { useMtaPrice } from '../../../../hooks/useMtaPrice';
 import { Button } from '../../../core/Button';
 import { useSelectedMassetName } from '../../../../context/SelectedMassetNameProvider';
 import { SaveModalHeader } from './SaveModalHeader';
-import { ADDRESSES } from '../../../../constants';
 
 const GOVERNANCE_URL = 'https://governance.mstable.org/#/stake';
 
@@ -112,54 +111,56 @@ export const Save: FC = () => {
         dollarExchangeRate={exchangeRate}
         masset={massetName}
       />
-      <div />
-      <Divider />
-      <div />
-      {ADDRESSES[massetName]?.SaveWrapper && massetName === 'musd' && (
-        <BalanceRow
-          token={BalanceType.BoostedSavingsVault}
-          apy={saveApy?.value}
-          highlight
-          rewards={<VaultROI />}
-          onClick={showVaultModal}
-          balance={vaultBalance ?? BigDecimal.ZERO}
-          dollarExchangeRate={exchangeRate}
-          masset={massetName}
-        >
-          {vaultBalance || hasRewards ? (
-            <Boost />
-          ) : (
-            <PotentialBoost>
-              {isCalculatorVisible ? (
-                <BoostCalculator
-                  onBackClick={() => setCalculatorVisible(false)}
-                />
-              ) : (
-                <Button
-                  scale={0.875}
-                  onClick={() => setCalculatorVisible(true)}
-                >
-                  Calculate rewards
-                </Button>
-              )}
-            </PotentialBoost>
-          )}
-        </BalanceRow>
+      {vault && (
+        <>
+          <div />
+          <Divider />
+          <div />
+          <BalanceRow
+            token={BalanceType.BoostedSavingsVault}
+            apy={saveApy?.value}
+            highlight
+            rewards={<VaultROI />}
+            onClick={showVaultModal}
+            balance={vaultBalance ?? BigDecimal.ZERO}
+            dollarExchangeRate={exchangeRate}
+            masset={massetName}
+          >
+            {vaultBalance || hasRewards ? (
+              <Boost />
+            ) : (
+              <PotentialBoost>
+                {isCalculatorVisible ? (
+                  <BoostCalculator
+                    onBackClick={() => setCalculatorVisible(false)}
+                  />
+                ) : (
+                  <Button
+                    scale={0.875}
+                    onClick={() => setCalculatorVisible(true)}
+                  >
+                    Calculate rewards
+                  </Button>
+                )}
+              </PotentialBoost>
+            )}
+          </BalanceRow>
+          <BalanceRow
+            token={BalanceType.Meta}
+            balance={metaToken?.balance}
+            dollarExchangeRate={mtaPrice}
+            masset={massetName}
+          />
+          <BalanceRow
+            token={BalanceType.VMeta}
+            balance={vMetaToken?.balance}
+            onClick={navigateToGovernance}
+            apy="Variable APY"
+            external
+            masset={massetName}
+          />
+        </>
       )}
-      <BalanceRow
-        token={BalanceType.Meta}
-        balance={metaToken?.balance}
-        dollarExchangeRate={mtaPrice}
-        masset={massetName}
-      />
-      <BalanceRow
-        token={BalanceType.VMeta}
-        balance={vMetaToken?.balance}
-        onClick={navigateToGovernance}
-        apy="Variable APY"
-        external
-        masset={massetName}
-      />
     </Container>
   );
 };

--- a/src/components/pages/Swap/amm/index.tsx
+++ b/src/components/pages/Swap/amm/index.tsx
@@ -110,7 +110,8 @@ const SwapLogic: FC = () => {
           _inputAddress &&
           _inputAmount &&
           _outputAddress &&
-          _outputDecimals
+          _outputDecimals &&
+          !!_inputAmount.simple
         ) {
           setSwapOutput({ fetching: true });
           _masset
@@ -193,6 +194,8 @@ const SwapLogic: FC = () => {
   // Calling `getSwapOutput` performs the complex validation;
   // this validation is trivial.
   const error = useMemo<string | undefined>(() => {
+    if (!inputAmount?.simple) return;
+
     if (swapOutput.error) return swapOutput.error;
 
     if (inputAmount) {

--- a/src/context/earn/useMatchStakingRewardsAddressFromUrl.ts
+++ b/src/context/earn/useMatchStakingRewardsAddressFromUrl.ts
@@ -21,8 +21,8 @@ export const useMatchStakingRewardsAddressFromUrl = (
       return undefined;
     }
 
-    const found = Object.values(stakingRewardsContracts).find(
-      item => item.earnUrl === `/earn/${slugOrAddress}`,
+    const found = Object.values(stakingRewardsContracts).find(item =>
+      item.earnUrl.includes(slugOrAddress),
     );
 
     return found?.address ?? false;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,12 +44,16 @@ const Routes: FC = () => {
   return (
     <Switch>
       <Route exact path="/" component={Home} />
-      <Route exact path="/earn" component={Earn} />
-      <Route exact path="/earn/admin" component={AdminPage} />
-      <Route exact path="/earn/:slugOrAddress" component={PoolPage} />
+      <Route exact path="/:massetName/earn" component={Earn} />
+      <Route exact path="/:massetName/earn/admin" component={AdminPage} />
       <Route
         exact
-        path="/earn/:slugOrAddress/:userAddress"
+        path="/:massetName/earn/:slugOrAddress"
+        component={PoolPage}
+      />
+      <Route
+        exact
+        path="/:massetName/earn/:slugOrAddress/:userAddress"
         component={PoolPage}
       />
       <Route exact path="/faq" component={FAQ} />
@@ -63,6 +67,9 @@ const Routes: FC = () => {
       <Redirect exact path="/redeem" to="/musd/redeem" />
       <Redirect exact path="/save" to="/musd/save" />
       <Redirect exact path="/swap" to="/musd/swap" />
+      <Redirect exact path="/earn" to="/musd/earn" />
+      <Redirect exact path="/musd" to="/musd/mint" />
+      <Redirect exact path="/mbtc" to="/mbtc/mint" />
       <Route component={NotFound} />
     </Switch>
   );


### PR DESCRIPTION
## Changelog:
- Filters Earn pools to MTA & current mAsset
- Navigates to `musd/earn` & `mbtc/earn`

### UI Fixes:
- Fixes Error on Swap page load
- Hides MTA, vMTA if no vault
- Expands Earn onboarding to fit container