### PR TITLE
Adjust Earn APY calculation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ const realConfig = {
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/naming-convention': 'off',
     'arrow-body-style': 'off',
+    radix: 'off',
     'no-underscore-dangle': 'off',
     'no-console': ['error', { allow: ['warn', 'error'] }],
     'react/no-unescaped-entities': 'off',

--- a/src/context/earn/EarnDataProvider.tsx
+++ b/src/context/earn/EarnDataProvider.tsx
@@ -26,7 +26,7 @@ export const EarnDataProvider: FC<{}> = ({ children }) => {
   // Data that we subscribe to on each block:
   // - Staking rewards contracts
   // - Curve pool balances (if available)
-  const rawEarnData = useRawEarnData(syncedEarnData);
+  const rawEarnData = useRawEarnData();
 
   const earnData = useMemo(
     () => transformEarnData(syncedEarnData, rawEarnData),

--- a/src/context/earn/types.ts
+++ b/src/context/earn/types.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers/utils';
-import { BlockTimestamp, Platforms, Token } from '../../types';
+import { Platforms, Token } from '../../types';
 import { BigDecimal } from '../../web3/BigDecimal';
 import {
   StakingRewardsContractsQueryResult,
@@ -12,18 +12,18 @@ import { CurveBalances, CurveJsonData } from './CurveProvider';
 
 export type RawPoolData = NonNullable<
   BalancerPoolsQueryResult['data']
->['current'][number];
+>['pools'][number];
 
 export type RawPairData = NonNullable<
   PairsQueryResult['data']
->['current'][number];
+>['pairs'][number];
 
 // export type RawCurvePoolsData = CurvePoolsQueryResult['data'];
 
 export interface RawPlatformPools {
-  [Platforms.Balancer]: { current: RawPoolData[]; historic: RawPoolData[] };
-  [Platforms.Uniswap]: { current: RawPairData[]; historic: RawPairData[] };
-  [Platforms.Sushi]: { current: RawPairData[]; historic: RawPairData[] };
+  [Platforms.Balancer]: RawPoolData[];
+  [Platforms.Uniswap]: RawPairData[];
+  [Platforms.Sushi]: RawPairData[];
   // [Platforms.Curve]: RawCurvePoolsData;
 }
 
@@ -38,7 +38,6 @@ export interface NormalizedPoolsMap {
 export type RawStakingRewardsContracts = StakingRewardsContractsQueryResult['data'];
 
 export interface RawSyncedEarnData {
-  block24hAgo?: BlockTimestamp;
   tokenPrices: TokenPricesMap;
   rawPlatformPools: RawPlatformPools;
   merkleDrops: { merkleDrops: MerkleDropsMap; refresh(): void };
@@ -47,11 +46,7 @@ export interface RawSyncedEarnData {
 }
 
 export interface SyncedEarnData {
-  block24hAgo?: BlockTimestamp;
-  pools: {
-    current: NormalizedPoolsMap;
-    historic: NormalizedPoolsMap;
-  };
+  pools: NormalizedPoolsMap;
   tokenPrices: TokenPricesMap;
   merkleDrops: { merkleDrops: MerkleDropsMap; refresh(): void };
   curveJsonData?: CurveJsonData;
@@ -67,7 +62,6 @@ export interface SyncedEarnData {
 // }
 
 export interface RawEarnData {
-  block24hAgo?: BlockTimestamp;
   curveBalances: CurveBalances;
   rawStakingRewardsContracts: RawStakingRewardsContracts;
 }
@@ -111,14 +105,12 @@ export interface StakingRewardsContract {
     platformRewardsEarned?: BigDecimal;
   };
   pool: NormalizedPool;
-  pool24hAgo?: NormalizedPool;
   duration: number;
   lastUpdateTime: number;
   periodFinish: number;
   expired: boolean;
   rewardRate: BigNumber;
   rewardPerTokenStoredNow: BigNumber;
-  rewardPerTokenStored24hAgo?: BigNumber;
   rewardsToken: Token & { price?: BigDecimal };
   stakingBalance: BigDecimal;
   stakingBalancePercentage: BigDecimal;
@@ -135,7 +127,6 @@ export interface StakingRewardsContract {
   };
   platformRewards?: {
     platformRewardPerTokenStoredNow: BigNumber;
-    platformRewardPerTokenStored24hAgo?: BigNumber;
     platformRewardRate: BigNumber;
     platformReward: { amount: BigDecimal; amountPerTokenPaid: BigDecimal };
     platformToken: Token & { price?: BigDecimal };
@@ -164,7 +155,6 @@ export interface MerkleDropsMap {
 }
 
 export interface EarnData {
-  block24hAgo?: BlockTimestamp;
   stakingRewardsContractsMap: StakingRewardsContractsMap;
   tokenPricesMap: TokenPricesMap;
   merkleDrops: { merkleDrops: MerkleDropsMap; refresh(): void };

--- a/src/context/earn/useRawEarnData.ts
+++ b/src/context/earn/useRawEarnData.ts
@@ -1,19 +1,16 @@
 import { useBlockPollingSubscription } from '../DataProvider/subscriptions';
 import { useAccount } from '../UserProvider';
 import { useStakingRewardsContractsLazyQuery } from '../../graphql/ecosystem';
-import { RawEarnData, SyncedEarnData } from './types';
+import { RawEarnData } from './types';
 import { useCurveBalances } from './CurveProvider';
 
-export const useRawEarnData = ({
-  block24hAgo,
-}: SyncedEarnData): RawEarnData => {
+export const useRawEarnData = (): RawEarnData => {
   const account = useAccount();
-  const block = { number: block24hAgo?.blockNumber ?? 0 };
 
   const stakingRewardsContractsSub = useBlockPollingSubscription(
     useStakingRewardsContractsLazyQuery,
     {
-      variables: { account: account ?? null, includeHistoric: !!block, block },
+      variables: { account: account ?? null },
       fetchPolicy: 'cache-and-network',
     },
   );
@@ -21,7 +18,6 @@ export const useRawEarnData = ({
   const curveBalances = useCurveBalances();
 
   return {
-    block24hAgo,
     curveBalances,
     rawStakingRewardsContracts: stakingRewardsContractsSub.data,
   };

--- a/src/graphql/balancer.tsx
+++ b/src/graphql/balancer.tsx
@@ -1448,12 +1448,10 @@ export type TokenPriceDetailsFragment = (
 
 export type PoolsQueryVariables = {
   ids: Array<Scalars['ID']>;
-  includeHistoric: Scalars['Boolean'];
-  block?: Maybe<Block_Height>;
 };
 
 
-export type PoolsQuery = { current: Array<PoolDetailsFragment>, historic: Array<PoolDetailsFragment> };
+export type PoolsQuery = { pools: Array<PoolDetailsFragment> };
 
 export type TokenPricesQueryVariables = {
   tokens: Array<Scalars['ID']>;
@@ -1493,11 +1491,8 @@ export const TokenPriceDetailsFragmentDoc = gql`
 }
     `;
 export const PoolsDocument = gql`
-    query Pools($ids: [ID!]!, $includeHistoric: Boolean!, $block: Block_height) @api(name: balancer) {
-  current: pools(where: {id_in: $ids}) {
-    ...PoolDetails
-  }
-  historic: pools(where: {id_in: $ids}, block: $block) @include(if: $includeHistoric) {
+    query Pools($ids: [ID!]!) @api(name: balancer) {
+  pools(where: {id_in: $ids}) {
     ...PoolDetails
   }
 }
@@ -1516,8 +1511,6 @@ export const PoolsDocument = gql`
  * const { data, loading, error } = usePoolsQuery({
  *   variables: {
  *      ids: // value for 'ids'
- *      includeHistoric: // value for 'includeHistoric'
- *      block: // value for 'block'
  *   },
  * });
  */

--- a/src/graphql/balancer/query.graphql
+++ b/src/graphql/balancer/query.graphql
@@ -19,13 +19,8 @@ fragment TokenPriceDetails on TokenPrice {
   decimals
 }
 
-query Pools($ids: [ID!]!, $includeHistoric: Boolean!, $block: Block_height)
-  @api(name: balancer) {
-  current: pools(where: { id_in: $ids }) {
-    ...PoolDetails
-  }
-  historic: pools(where: { id_in: $ids }, block: $block)
-    @include(if: $includeHistoric) {
+query Pools($ids: [ID!]!) @api(name: balancer) {
+  pools(where: { id_in: $ids }) {
     ...PoolDetails
   }
 }

--- a/src/graphql/ecosystem.tsx
+++ b/src/graphql/ecosystem.tsx
@@ -1848,17 +1848,12 @@ export type StakingRewardsContractQuery = { stakingRewardsContract?: Maybe<(
 
 export type StakingRewardsContractsQueryVariables = {
   account?: Maybe<Scalars['Bytes']>;
-  includeHistoric: Scalars['Boolean'];
-  block?: Maybe<Block_Height>;
 };
 
 
-export type StakingRewardsContractsQuery = { current: Array<(
+export type StakingRewardsContractsQuery = { stakingRewardsContracts: Array<(
     { stakingBalances: Array<Pick<StakingBalance, 'amount'>>, stakingRewards: Array<Pick<StakingReward, 'amount' | 'amountPerTokenPaid'>>, platformRewards: Array<Pick<StakingReward, 'amount' | 'amountPerTokenPaid'>> }
     & StakingRewardsContractDetailsFragment
-  )>, historic: Array<(
-    Pick<StakingRewardsContract, 'id' | 'lastUpdateTime' | 'rewardPerTokenStored' | 'platformRewardPerTokenStored'>
-    & { address: StakingRewardsContract['id'] }
   )> };
 
 export type RewardsDistributorQueryVariables = {};
@@ -2012,8 +2007,8 @@ export type StakingRewardsContractQueryHookResult = ReturnType<typeof useStaking
 export type StakingRewardsContractLazyQueryHookResult = ReturnType<typeof useStakingRewardsContractLazyQuery>;
 export type StakingRewardsContractQueryResult = ApolloReactCommon.QueryResult<StakingRewardsContractQuery, StakingRewardsContractQueryVariables>;
 export const StakingRewardsContractsDocument = gql`
-    query StakingRewardsContracts($account: Bytes, $includeHistoric: Boolean!, $block: Block_height) @api(name: ecosystem) {
-  current: stakingRewardsContracts {
+    query StakingRewardsContracts($account: Bytes) @api(name: ecosystem) {
+  stakingRewardsContracts {
     ...StakingRewardsContractDetails
     stakingBalances(where: {account: $account}) {
       amount
@@ -2026,13 +2021,6 @@ export const StakingRewardsContractsDocument = gql`
       amount
       amountPerTokenPaid
     }
-  }
-  historic: stakingRewardsContracts(block: $block) @include(if: $includeHistoric) {
-    address: id
-    id
-    lastUpdateTime
-    rewardPerTokenStored
-    platformRewardPerTokenStored
   }
 }
     ${StakingRewardsContractDetailsFragmentDoc}`;
@@ -2050,8 +2038,6 @@ export const StakingRewardsContractsDocument = gql`
  * const { data, loading, error } = useStakingRewardsContractsQuery({
  *   variables: {
  *      account: // value for 'account'
- *      includeHistoric: // value for 'includeHistoric'
- *      block: // value for 'block'
  *   },
  * });
  */

--- a/src/graphql/ecosystem/query.graphql
+++ b/src/graphql/ecosystem/query.graphql
@@ -49,12 +49,8 @@ query StakingRewardsContract($id: ID!, $account: Bytes) @api(name: ecosystem) {
   }
 }
 
-query StakingRewardsContracts(
-  $account: Bytes
-  $includeHistoric: Boolean!
-  $block: Block_height
-) @api(name: ecosystem) {
-  current: stakingRewardsContracts {
+query StakingRewardsContracts($account: Bytes) @api(name: ecosystem) {
+  stakingRewardsContracts {
     ...StakingRewardsContractDetails
     stakingBalances(where: { account: $account }) {
       amount
@@ -69,14 +65,6 @@ query StakingRewardsContracts(
       amount
       amountPerTokenPaid
     }
-  }
-  historic: stakingRewardsContracts(block: $block)
-    @include(if: $includeHistoric) {
-    address: id
-    id
-    lastUpdateTime
-    rewardPerTokenStored
-    platformRewardPerTokenStored
   }
 }
 

--- a/src/graphql/sushi.tsx
+++ b/src/graphql/sushi.tsx
@@ -2393,12 +2393,10 @@ export type PairDetailsFragment = (
 
 export type SushiPairsQueryVariables = {
   ids: Array<Scalars['ID']>;
-  includeHistoric: Scalars['Boolean'];
-  block?: Maybe<Block_Height>;
 };
 
 
-export type SushiPairsQuery = { current: Array<PairDetailsFragment>, historic: Array<PairDetailsFragment> };
+export type SushiPairsQuery = { pairs: Array<PairDetailsFragment> };
 
 export const PairDetailsFragmentDoc = gql`
     fragment PairDetails on Pair {
@@ -2422,11 +2420,8 @@ export const PairDetailsFragmentDoc = gql`
 }
     `;
 export const SushiPairsDocument = gql`
-    query SushiPairs($ids: [ID!]!, $includeHistoric: Boolean!, $block: Block_height) @api(name: sushi) {
-  current: pairs(where: {id_in: $ids}) {
-    ...PairDetails
-  }
-  historic: pairs(where: {id_in: $ids}, block: $block) @include(if: $includeHistoric) {
+    query SushiPairs($ids: [ID!]!) @api(name: sushi) {
+  pairs(where: {id_in: $ids}) {
     ...PairDetails
   }
 }
@@ -2445,8 +2440,6 @@ export const SushiPairsDocument = gql`
  * const { data, loading, error } = useSushiPairsQuery({
  *   variables: {
  *      ids: // value for 'ids'
- *      includeHistoric: // value for 'includeHistoric'
- *      block: // value for 'block'
  *   },
  * });
  */

--- a/src/graphql/sushi/query.graphql
+++ b/src/graphql/sushi/query.graphql
@@ -18,16 +18,8 @@ fragment PairDetails on Pair {
   }
 }
 
-query SushiPairs(
-  $ids: [ID!]!
-  $includeHistoric: Boolean!
-  $block: Block_height
-) @api(name: sushi) {
-  current: pairs(where: { id_in: $ids }) {
-    ...PairDetails
-  }
-  historic: pairs(where: { id_in: $ids }, block: $block)
-    @include(if: $includeHistoric) {
+query SushiPairs($ids: [ID!]!) @api(name: sushi) {
+  pairs(where: { id_in: $ids }) {
     ...PairDetails
   }
 }

--- a/src/graphql/uniswap.tsx
+++ b/src/graphql/uniswap.tsx
@@ -2511,12 +2511,10 @@ export type PairDetailsFragment = (
 
 export type PairsQueryVariables = {
   ids: Array<Scalars['ID']>;
-  includeHistoric: Scalars['Boolean'];
-  block?: Maybe<Block_Height>;
 };
 
 
-export type PairsQuery = { current: Array<PairDetailsFragment>, historic: Array<PairDetailsFragment> };
+export type PairsQuery = { pairs: Array<PairDetailsFragment> };
 
 export const PairDetailsFragmentDoc = gql`
     fragment PairDetails on Pair {
@@ -2540,11 +2538,8 @@ export const PairDetailsFragmentDoc = gql`
 }
     `;
 export const PairsDocument = gql`
-    query Pairs($ids: [ID!]!, $includeHistoric: Boolean!, $block: Block_height) @api(name: uniswap) {
-  current: pairs(where: {id_in: $ids}) {
-    ...PairDetails
-  }
-  historic: pairs(where: {id_in: $ids}, block: $block) @include(if: $includeHistoric) {
+    query Pairs($ids: [ID!]!) @api(name: uniswap) {
+  pairs(where: {id_in: $ids}) {
     ...PairDetails
   }
 }
@@ -2563,8 +2558,6 @@ export const PairsDocument = gql`
  * const { data, loading, error } = usePairsQuery({
  *   variables: {
  *      ids: // value for 'ids'
- *      includeHistoric: // value for 'includeHistoric'
- *      block: // value for 'block'
  *   },
  * });
  */

--- a/src/graphql/uniswap/query.graphql
+++ b/src/graphql/uniswap/query.graphql
@@ -18,11 +18,8 @@ fragment PairDetails on Pair {
   }
 }
 
-query Pairs($ids: [ID!]!, $includeHistoric: Boolean!, $block: Block_height) @api(name: uniswap) {
-  current: pairs(where: { id_in: $ids }) {
-    ...PairDetails
-  }
-  historic: pairs(where: { id_in: $ids }, block: $block) @include(if: $includeHistoric) {
+query Pairs($ids: [ID!]!) @api(name: uniswap) {
+  pairs(where: { id_in: $ids }) {
     ...PairDetails
   }
 }


### PR DESCRIPTION
- Adjust the Earn APY calculation to provide more accurate numbers when transactions are more sparse, e.g. when gas prices are extremely high. The reward per day per token (based on the current reward token price) is calculated and a daily APY is derived from this (based on the current staking token price).