### PR TITLE
Restore saveViaETH + Tab refactor

### DIFF
--- a/src/components/core/Tabs.tsx
+++ b/src/components/core/Tabs.tsx
@@ -1,6 +1,7 @@
+import React, { FC, ReactElement } from 'react';
 import styled from 'styled-components';
 import { UnstyledButton } from './Button';
-import { Color, FontSize, ViewportWidth } from '../../theme';
+import { Color, ViewportWidth } from '../../theme';
 import { InfoMessage } from './InfoMessage';
 
 export const TabsContainer = styled.div`
@@ -11,14 +12,15 @@ export const TabsContainer = styled.div`
 
 export const TabBtn = styled(UnstyledButton)<{ active: boolean }>`
   cursor: pointer;
-  border-bottom: 4px
-    ${({ active, theme }) => (active ? theme.color.primary : 'transparent')}
+  border-bottom: 2px
+    ${({ active, theme }) =>
+      active ? theme.color.primary : theme.color.accent}
     solid;
   background: transparent;
   color: ${({ active, theme }) => (active ? theme.color.primary : Color.grey)};
   padding: 0.75rem 0.5rem;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.875rem;
   width: 100%;
   transition: border-bottom-color 0.2s ease;
 
@@ -28,9 +30,37 @@ export const TabBtn = styled(UnstyledButton)<{ active: boolean }>`
   }
 
   @media (min-width: ${ViewportWidth.s}) {
-    font-size: ${FontSize.m};
+    font-size: 1rem;
   }
 `;
+
+export const TabSwitch: FC<{
+  tabs: Record<string, { title: string; component?: ReactElement }>;
+  active: string;
+  onClick: (key: string) => void;
+}> = ({ tabs, children, active, onClick }) => {
+  return (
+    <>
+      <TabsContainer>
+        {Object.keys(tabs)
+          .filter(key => !!tabs[key].component)
+          .map(_key => (
+            <TabBtn
+              key={_key}
+              active={active === _key}
+              onClick={() => {
+                onClick(_key);
+              }}
+            >
+              {tabs[_key].title}
+            </TabBtn>
+          ))}
+      </TabsContainer>
+      {children && children}
+      {active && tabs[active]?.component}
+    </>
+  );
+};
 
 export const MoreInfo = styled.div`
   font-size: 0.875rem;

--- a/src/components/pages/Save/v2/SaveDepositETH.tsx
+++ b/src/components/pages/Save/v2/SaveDepositETH.tsx
@@ -102,7 +102,7 @@ export const SaveDepositETH: FC<{
   const saveExchangeRate = savingsContract?.latestExchangeRate?.rate;
   const saveAddress = savingsContract?.address;
   const saveWrapperAddress =
-    ADDRESSES[massetSymbol as 'mbtc' | 'musd']?.SaveWrapper;
+    ADDRESSES[massetSymbol?.toLowerCase() as 'mbtc' | 'musd']?.SaveWrapper;
 
   const [inputAmount, inputFormValue, setInputFormValue] = useBigDecimalInput();
   const [uniswapAmountOut, setUniswapAmountOut] = useState<{
@@ -168,7 +168,12 @@ export const SaveDepositETH: FC<{
     };
   }, [inputAmount, saveExchangeRate, uniswapAmountOut]);
 
-  const valid = !!(!error && inputAmount && inputAmount.simple > 0);
+  const valid = !!(
+    !error &&
+    inputAmount &&
+    inputAmount.simple > 0 &&
+    (exchangeRate?.value?.simple ?? 0) > 0
+  );
 
   useEffect(() => {
     setUniswapAmountOut({ fetching: true });
@@ -176,7 +181,7 @@ export const SaveDepositETH: FC<{
 
   useDebounce(
     () => {
-      if (valid && inputAmount && uniswap && massetState) {
+      if (inputAmount && uniswap && massetState) {
         getUniswapBassetOutputForETH(uniswap, inputAmount, massetState)
           .then(optimalBasset => {
             setUniswapAmountOut({
@@ -190,7 +195,7 @@ export const SaveDepositETH: FC<{
       }
     },
     2000,
-    [inputAmount, valid, signer, massetState],
+    [inputAmount, signer, massetState],
   );
 
   return (


### PR DESCRIPTION
## Changelog:
- Restored saveViaETH as it got knocked with the mBTC update
- saveViaETH for mUSD only
- Refactor Tab logic to pass title + component
- Slight tweak to Tab switcher UI

## Screenshot:
<img width="854" alt="Screenshot 2021-03-09 at 17 10 40" src="https://user-images.githubusercontent.com/19643324/110509792-69321000-80fa-11eb-95dd-597a346e9a3e.png">
