### PR TITLE
Undergoing recollateral message

### DIFF
--- a/src/components/core/Tabs.tsx
+++ b/src/components/core/Tabs.tsx
@@ -7,7 +7,7 @@ import { InfoMessage } from './InfoMessage';
 export const TabsContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  margin: 0.5rem 0;
+  margin: 0.5rem 0 1.25rem;
 `;
 
 export const TabBtn = styled(UnstyledButton)<{ active: boolean }>`
@@ -38,10 +38,11 @@ export const TabSwitch: FC<{
   tabs: Record<string, { title: string; component?: ReactElement }>;
   active: string;
   onClick: (key: string) => void;
-}> = ({ tabs, children, active, onClick }) => {
+  className?: string;
+}> = ({ tabs, children, active, onClick, className }) => {
   return (
     <>
-      <TabsContainer>
+      <TabsContainer className={className}>
         {Object.keys(tabs)
           .filter(key => !!tabs[key].component)
           .map(_key => (
@@ -70,5 +71,5 @@ export const MoreInfo = styled.div`
 `;
 
 export const Message = styled(InfoMessage)`
-  margin: 2rem 2rem 0 2rem;
+  margin: 0 2rem;
 `;

--- a/src/components/layout/BannerMessage.tsx
+++ b/src/components/layout/BannerMessage.tsx
@@ -32,9 +32,9 @@ const Container = styled.div`
 `;
 
 export const BannerMessage: FC = () => {
-  const bannerMessage = useBannerMessage();
+  const [bannerMessage] = useBannerMessage();
 
-  return bannerMessage?.visible ? (
+  return bannerMessage?.title ? (
     <Container>
       <span role="img" aria-label="emoji">
         {bannerMessage.emoji}

--- a/src/components/layout/BannerMessage.tsx
+++ b/src/components/layout/BannerMessage.tsx
@@ -31,6 +31,7 @@ const Container = styled.div`
   }
 `;
 
+// TODO: - Remove useEffect to set message - change to use provider & memoised props
 export const BannerMessage: FC = () => {
   const [bannerMessage] = useBannerMessage();
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -263,9 +263,7 @@ export const Layout: FC = ({ children }) => {
         undefined;
 
       message = recollatMessage ?? saveV2Message;
-    }
-
-    if (massetName === 'mbtc') {
+    } else if (massetName === 'mbtc') {
       message =
         (pathname === '/mbtc/mint' && MessageHandler.tvlCap({ tvlCap })) ||
         undefined;

--- a/src/components/layout/MessageHandler.tsx
+++ b/src/components/layout/MessageHandler.tsx
@@ -1,0 +1,47 @@
+import { BannerMessage } from '../../context/AppProvider';
+import { formatMassetName } from '../../context/SelectedMassetNameProvider';
+import { MassetName } from '../../types';
+import { BigDecimal } from '../../web3/BigDecimal';
+
+interface Props {
+  saveV2: ({
+    hasV1Balance,
+    pathname,
+  }: {
+    hasV1Balance: boolean;
+    pathname: string;
+  }) => BannerMessage | undefined;
+  recollat: ({
+    massetName,
+  }: {
+    massetName: MassetName;
+  }) => BannerMessage | undefined;
+  tvlCap: ({ tvlCap }: { tvlCap?: BigDecimal }) => BannerMessage | undefined;
+}
+
+export const MessageHandler: Props = {
+  saveV2: ({ hasV1Balance, pathname }) => ({
+    emoji: '🚀',
+    title: 'SAVE V2 has launched!',
+    subtitle: hasV1Balance
+      ? 'Migrate your funds now to keep earning interest.'
+      : undefined,
+    url: pathname !== '/musd/save' ? '/musd/save' : undefined,
+  }),
+  recollat: ({ massetName }) => {
+    const formattedMasset = formatMassetName(massetName);
+    return {
+      title: `${formattedMasset} is currently undergoing recollateralisation. `,
+      subtitle: `During this time,
+    mAsset functionality will be reduced in order to restore a healthy
+    basket state.`,
+      emoji: '⚠️',
+    };
+  },
+  tvlCap: ({ tvlCap }) =>
+    tvlCap && {
+      title: `Current TVL cap is ${tvlCap.format(4, false)} mBTC. `,
+      emoji: '⚠️',
+      url: 'https://medium.com/mstable/mstable-launches-mbtc-e26a246dc0bb',
+    },
+};

--- a/src/components/pages/Earn/index.tsx
+++ b/src/components/pages/Earn/index.tsx
@@ -19,7 +19,6 @@ import { PoolsOverview } from './PoolsOverview';
 import { Card } from './Card';
 import { MerkleDropClaims } from './MerkleDropClaims';
 import { CurveProvider } from '../../../context/earn/CurveProvider';
-import { MassetPage } from '../MassetPage';
 
 const [useSwipeDisabled, SwipeDisabledProvider] = createStateContext(false);
 
@@ -375,10 +374,8 @@ const EarnContent: FC = () => {
             action={PageAction.Earn}
             subtitle="Ecosystem rewards with mStable"
           />
-          <MassetPage>
-            <MerkleClaims />
-            <PoolsOverview />
-          </MassetPage>
+          <MerkleClaims />
+          <PoolsOverview />
         </Content>
       )}
     </Container>

--- a/src/components/pages/Earn/index.tsx
+++ b/src/components/pages/Earn/index.tsx
@@ -19,6 +19,7 @@ import { PoolsOverview } from './PoolsOverview';
 import { Card } from './Card';
 import { MerkleDropClaims } from './MerkleDropClaims';
 import { CurveProvider } from '../../../context/earn/CurveProvider';
+import { MassetPage } from '../MassetPage';
 
 const [useSwipeDisabled, SwipeDisabledProvider] = createStateContext(false);
 
@@ -374,8 +375,10 @@ const EarnContent: FC = () => {
             action={PageAction.Earn}
             subtitle="Ecosystem rewards with mStable"
           />
-          <MerkleClaims />
-          <PoolsOverview />
+          <MassetPage>
+            <MerkleClaims />
+            <PoolsOverview />
+          </MassetPage>
         </Content>
       )}
     </Container>

--- a/src/components/pages/MassetPage.tsx
+++ b/src/components/pages/MassetPage.tsx
@@ -1,10 +1,15 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { MassetState } from '../../context/DataProvider/types';
 import { useSelectedMassetState } from '../../context/DataProvider/DataProvider';
 
 import { SimpleMassetStats } from '../stats/SimpleMassetStats';
+import { useBannerMessage } from '../../context/AppProvider';
+import {
+  formatMassetName,
+  useSelectedMassetName,
+} from '../../context/SelectedMassetNameProvider';
 
 const MassetAsideContainer = styled.aside`
   padding: 1rem;
@@ -58,7 +63,7 @@ const Separator = styled.div`
   }
 `;
 
-const Container = styled.div`
+const Inner = styled.div`
   @media (min-width: ${({ theme }) => theme.viewportWidth.l}) {
     display: flex;
     flex-direction: row;
@@ -77,12 +82,77 @@ const Container = styled.div`
   }
 `;
 
-export const MassetPage: FC = ({ children }) => {
+const MigrationOverlay = styled.div`
+  * {
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  opacity: 0.75;
+  background: ${({ theme }) => theme.color.background};
+  z-index: 4;
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+`;
+
+const Container = styled.div`
+  position: relative;
+`;
+
+export const MassetPage: FC<{ asideVisible?: boolean }> = ({
+  children,
+  asideVisible,
+}) => {
+  const [bannerMessage, setBannerMessage] = useBannerMessage();
+  const massetName = useSelectedMassetName();
+  const formattedMasset = formatMassetName(massetName);
+  const { undergoingRecol } = useSelectedMassetState() ?? {};
+
+  const message = useMemo(
+    () => ({
+      title: `${formattedMasset} is currently undergoing recollateralisation. `,
+      subtitle: `During this time,
+      mAsset functionality will be reduced in order to restore a healthy
+      basket state.`,
+      emoji: '⚠️',
+    }),
+    [formattedMasset],
+  );
+
+  useEffect(() => {
+    if (!undergoingRecol) {
+      if (bannerMessage?.title === message?.title) {
+        setBannerMessage(undefined);
+      }
+      return;
+    }
+
+    if (bannerMessage?.title !== message?.title) {
+      setBannerMessage(message);
+    }
+  }, [
+    bannerMessage,
+    formattedMasset,
+    message,
+    setBannerMessage,
+    undergoingRecol,
+  ]);
+
   return (
     <Container>
-      <div>{children}</div>
-      <Separator />
-      <MassetAside />
+      {undergoingRecol && <MigrationOverlay />}
+      {asideVisible ? (
+        <Inner>
+          <div>{children}</div>
+          <Separator />
+          <MassetAside />
+        </Inner>
+      ) : (
+        <div>{children}</div>
+      )}
     </Container>
   );
 };

--- a/src/components/pages/MassetPage.tsx
+++ b/src/components/pages/MassetPage.tsx
@@ -1,15 +1,10 @@
-import React, { FC, useEffect, useMemo } from 'react';
+import React, { FC } from 'react';
 import styled from 'styled-components';
 
 import { MassetState } from '../../context/DataProvider/types';
 import { useSelectedMassetState } from '../../context/DataProvider/DataProvider';
 
 import { SimpleMassetStats } from '../stats/SimpleMassetStats';
-import { useBannerMessage } from '../../context/AppProvider';
-import {
-  formatMassetName,
-  useSelectedMassetName,
-} from '../../context/SelectedMassetNameProvider';
 
 const MassetAsideContainer = styled.aside`
   padding: 1rem;
@@ -106,41 +101,7 @@ export const MassetPage: FC<{ asideVisible?: boolean }> = ({
   children,
   asideVisible,
 }) => {
-  const [bannerMessage, setBannerMessage] = useBannerMessage();
-  const massetName = useSelectedMassetName();
-  const formattedMasset = formatMassetName(massetName);
   const { undergoingRecol } = useSelectedMassetState() ?? {};
-
-  const message = useMemo(
-    () => ({
-      title: `${formattedMasset} is currently undergoing recollateralisation. `,
-      subtitle: `During this time,
-      mAsset functionality will be reduced in order to restore a healthy
-      basket state.`,
-      emoji: '⚠️',
-    }),
-    [formattedMasset],
-  );
-
-  useEffect(() => {
-    if (!undergoingRecol) {
-      if (bannerMessage?.title === message?.title) {
-        setBannerMessage(undefined);
-      }
-      return;
-    }
-
-    if (bannerMessage?.title !== message?.title) {
-      setBannerMessage(message);
-    }
-  }, [
-    bannerMessage,
-    formattedMasset,
-    message,
-    setBannerMessage,
-    undergoingRecol,
-  ]);
-
   return (
     <Container>
       {undergoingRecol && <MigrationOverlay />}

--- a/src/components/pages/Mint/amm/index.tsx
+++ b/src/components/pages/Mint/amm/index.tsx
@@ -311,7 +311,6 @@ export const Mint: FC = () => {
     const message: BannerMessage = {
       title: `Current TVL cap is ${tvlCap.format(4, false)} mBTC. `,
       emoji: '⚠️',
-      visible: true,
       url: 'https://medium.com/mstable/mstable-launches-mbtc-e26a246dc0bb',
     };
 
@@ -339,7 +338,7 @@ export const Mint: FC = () => {
         action={PageAction.Mint}
         subtitle={`Convert into ${massetState.token.symbol}`}
       />
-      <MassetPage>
+      <MassetPage asideVisible>
         <MintLogic />
       </MassetPage>
     </MultiAssetExchangeProvider>

--- a/src/components/pages/Mint/amm/index.tsx
+++ b/src/components/pages/Mint/amm/index.tsx
@@ -1,9 +1,8 @@
-import React, { FC, useEffect, useMemo } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useThrottleFn } from 'react-use';
 import { BigNumber } from 'ethers';
 import { Masset__factory } from '@mstable/protocol/types/generated/factories/Masset__factory';
 import { Masset } from '@mstable/protocol/types/generated/Masset';
-import { getUnixTime } from 'date-fns';
 
 import { useTokens, useTokensState } from '../../../../context/TokensProvider';
 import { useSelectedMassetState } from '../../../../context/DataProvider/DataProvider';
@@ -27,13 +26,8 @@ import {
 } from '../../../forms/MultiAssetExchange';
 import { SendButton } from '../../../forms/SendButton';
 import { MassetState } from '../../../../context/DataProvider/types';
-import {
-  BannerMessage,
-  useSetBannerMessage,
-} from '../../../../context/AppProvider';
 import { PageHeader, PageAction } from '../../PageHeader';
 import { MassetPage } from '../../MassetPage';
-import { SCALE } from '../../../../constants';
 import {
   getBounds,
   getEstimatedOutput,
@@ -281,41 +275,6 @@ const MintLogic: FC = () => {
 
 export const Mint: FC = () => {
   const massetState = useSelectedMassetState();
-  const setBannerMessage = useSetBannerMessage();
-
-  const { invariantStartingCap, invariantStartTime, invariantCapFactor } =
-    massetState ?? {};
-
-  const tvlCap = useMemo(() => {
-    if (!invariantStartingCap || !invariantStartTime || !invariantCapFactor)
-      return;
-
-    const currentTime = getUnixTime(Date.now());
-    const weeksSinceLaunch = BigNumber.from(currentTime)
-      .sub(invariantStartTime)
-      .mul(SCALE)
-      .div(604800);
-
-    if (weeksSinceLaunch.gt(SCALE.mul(7))) return;
-
-    const maxK = invariantStartingCap.add(
-      invariantCapFactor.mul(weeksSinceLaunch.pow(2)).div(SCALE.pow(2)),
-    );
-
-    return new BigDecimal(maxK);
-  }, [invariantCapFactor, invariantStartTime, invariantStartingCap]);
-
-  useEffect(() => {
-    if (!tvlCap) return;
-
-    const message: BannerMessage = {
-      title: `Current TVL cap is ${tvlCap.format(4, false)} mBTC. `,
-      emoji: '⚠️',
-      url: 'https://medium.com/mstable/mstable-launches-mbtc-e26a246dc0bb',
-    };
-
-    setBannerMessage(message);
-  }, [setBannerMessage, tvlCap]);
 
   const inputAssets = useMemo(
     () =>

--- a/src/components/pages/Mint/legacy/index.tsx
+++ b/src/components/pages/Mint/legacy/index.tsx
@@ -91,10 +91,10 @@ export const Mint: FC = () => {
         action={PageAction.Mint}
         subtitle="Convert stablecoins into mUSD"
       />
-      <MassetPage>
+      <MassetPage asideVisible>
         <MintForm />
+        <MassetStats />
       </MassetPage>
-      <MassetStats />
     </MintProvider>
   ) : (
     <Skeleton height={400} />

--- a/src/components/pages/PageHeader.tsx
+++ b/src/components/pages/PageHeader.tsx
@@ -102,12 +102,12 @@ const ChildrenRow = styled.div`
 
 export const PageHeader: FC<Props> = ({ children, action, subtitle }) => {
   const accountOpen = useAccountOpen();
-  const { visible } = useBannerMessage() ?? {};
+  const [bannerMessage] = useBannerMessage();
   const icon = ActionIcons[action];
 
   return (
     <div>
-      <Container accountOpen={accountOpen} messageVisible={visible}>
+      <Container accountOpen={accountOpen} messageVisible={!!bannerMessage}>
         <Row>
           <Icon inverted>{icon}</Icon>
           <h2>{action}</h2>
@@ -115,7 +115,7 @@ export const PageHeader: FC<Props> = ({ children, action, subtitle }) => {
         {subtitle && <p>{subtitle}</p>}
         {children && <ChildrenRow>{children}</ChildrenRow>}
       </Container>
-      {visible && <BannerMessage />}
+      {!!bannerMessage && <BannerMessage />}
     </div>
   );
 };

--- a/src/components/pages/Redeem/amm/index.tsx
+++ b/src/components/pages/Redeem/amm/index.tsx
@@ -1,57 +1,43 @@
 import React, { FC, useState } from 'react';
-import styled from 'styled-components';
 import Skeleton from 'react-loading-skeleton';
 
 import { useSelectedMassetState } from '../../../../context/DataProvider/DataProvider';
 import { PageAction, PageHeader } from '../../PageHeader';
 import { RedeemExactBassets } from './RedeemExactBassets';
 import { RedeemMasset } from './RedeemMasset';
-import { Toggle } from '../../../core/Toggle';
 import { MassetPage } from '../../MassetPage';
+import { TabSwitch } from '../../../core/Tabs';
 
-enum ToggleOption {
+enum Tabs {
   Single = 'Single',
   Multiple = 'Multiple',
 }
 
-const { Single, Multiple } = ToggleOption;
-
-const title: { [key in ToggleOption]: string } = {
-  [Single]: 'mBTC Amount',
-  [Multiple]: 'Underlying Amount',
+const tabs = {
+  [Tabs.Single]: {
+    title: `mBTC Amount`,
+    subtitle: 'Redeem an exact amount of mBTC for its underlying collateral',
+    component: <RedeemMasset />,
+  },
+  [Tabs.Multiple]: {
+    title: 'Underlying Amount',
+    subtitle: 'Redeem mBTC for an exact amount of its underlying collateral',
+    component: <RedeemExactBassets />,
+  },
 };
-
-const info: { [key in ToggleOption]: string } = {
-  [Single]: 'Redeem an exact amount of mBTC for its underlying collateral',
-  [Multiple]: 'Redeem mBTC for an exact amount of its underlying collateral',
-};
-
-const ToggleContainer = styled.div`
-  display: flex;
-  align-items: flex-start;
-  margin-bottom: 1rem;
-`;
 
 export const Redeem: FC = () => {
   const massetState = useSelectedMassetState();
-  const [currentTab, setSelectedTab] = useState(Single);
-
-  const toggleOptions = Object.keys(title).map(tab => ({
-    title: title[tab as ToggleOption],
-    onClick: () => setSelectedTab(tab as ToggleOption),
-    active: currentTab === tab,
-  }));
-
-  const isExactBassets = currentTab !== ToggleOption.Single;
+  const [activeTab, setActiveTab] = useState<string>(Tabs.Single as string);
 
   return massetState ? (
     <div>
-      <PageHeader action={PageAction.Redeem} subtitle={info[currentTab]} />
-      <ToggleContainer>
-        <Toggle options={toggleOptions} />
-      </ToggleContainer>
-      <MassetPage>
-        {isExactBassets ? <RedeemExactBassets /> : <RedeemMasset />}
+      <PageHeader
+        action={PageAction.Redeem}
+        subtitle={tabs[activeTab as Tabs].subtitle}
+      />
+      <MassetPage asideVisible>
+        <TabSwitch tabs={tabs} active={activeTab} onClick={setActiveTab} />
       </MassetPage>
     </div>
   ) : (

--- a/src/components/pages/Redeem/legacy/index.tsx
+++ b/src/components/pages/Redeem/legacy/index.tsx
@@ -99,7 +99,7 @@ export const Redeem: FC = () => {
         action={PageAction.Redeem}
         subtitle="Exchange mUSD for its underlying collateral"
       />
-      <MassetPage>
+      <MassetPage asideVisible>
         <RedeemForm />
       </MassetPage>
     </RedeemProvider>

--- a/src/components/pages/Save/index.tsx
+++ b/src/components/pages/Save/index.tsx
@@ -10,6 +10,7 @@ import { WeeklySaveAPY } from './WeeklySaveAPY';
 import { Save as SaveV1 } from './v1';
 import { Save as SaveV2 } from './v2';
 import { useSelectedMassetName } from '../../../context/SelectedMassetNameProvider';
+import { MassetPage } from '../MassetPage';
 
 const VersionToggle = styled(ToggleSave)`
   margin-bottom: 1rem;
@@ -25,8 +26,10 @@ export const Save: FC = () => {
       <PageHeader action={PageAction.Save}>
         <WeeklySaveAPY />
       </PageHeader>
-      {massetName === 'musd' ? <VersionToggle /> : <div />}
-      {selectedSaveVersion === 1 ? <SaveV1 /> : <SaveV2 />}
+      <MassetPage>
+        {massetName === 'musd' ? <VersionToggle /> : <div />}
+        {selectedSaveVersion === 1 ? <SaveV1 /> : <SaveV2 />}
+      </MassetPage>
     </>
   ) : (
     <Skeleton height={400} />

--- a/src/components/pages/Swap/amm/index.tsx
+++ b/src/components/pages/Swap/amm/index.tsx
@@ -322,7 +322,7 @@ export const Swap: FC = () => {
         subtitle="Swap the underlying collateral of mBTC"
       />
       {massetState ? (
-        <MassetPage>
+        <MassetPage asideVisible>
           <SwapLogic />
         </MassetPage>
       ) : (

--- a/src/components/pages/Swap/legacy/index.tsx
+++ b/src/components/pages/Swap/legacy/index.tsx
@@ -101,10 +101,10 @@ export const Swap: FC = () => {
         action={PageAction.Swap}
         subtitle="Exchange stablecoins with zero-slippage"
       />
-      <MassetPage>
+      <MassetPage asideVisible>
         <SwapForm />
+        <MassetStats />
       </MassetPage>
-      <MassetStats />
     </SwapProvider>
   ) : (
     <Skeleton height={400} />

--- a/src/context/AppProvider.tsx
+++ b/src/context/AppProvider.tsx
@@ -20,7 +20,6 @@ export interface BannerMessage {
   subtitle?: string;
   emoji: string;
   url?: string;
-  visible: boolean;
 }
 
 export type ThemeMode = 'light' | 'dark';
@@ -288,8 +287,10 @@ export const useAppStatusWarnings = (): StatusWarnings[] => {
 export const useToggleWallet = (): Dispatch['toggleWallet'] =>
   useAppDispatch().toggleWallet;
 
-export const useBannerMessage = (): State['bannerMessage'] =>
-  useAppState().bannerMessage;
+export const useBannerMessage = (): [
+  State['bannerMessage'],
+  Dispatch['setBannerMessage'],
+] => [useAppState().bannerMessage, useAppDispatch().setBannerMessage];
 
 export const useSetBannerMessage = (): Dispatch['setBannerMessage'] =>
   useAppDispatch().setBannerMessage;

--- a/src/context/SelectedSaveVersionProvider.tsx
+++ b/src/context/SelectedSaveVersionProvider.tsx
@@ -8,14 +8,12 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useLocation } from 'react-router-dom';
 
 import { useSelectedMassetState } from './DataProvider/DataProvider';
 import { SavingsContractState } from './DataProvider/types';
 import { useSelectedMassetName } from './SelectedMassetNameProvider';
 import { useWalletAddress } from './OnboardProvider';
 import { useV1SavingsBalanceQuery } from '../graphql/protocol';
-import { BannerMessage, useSetBannerMessage } from './AppProvider';
 
 export enum SaveVersion {
   V1 = 1,
@@ -34,9 +32,6 @@ export const SelectedSaveVersionProvider: FC = ({ children }) => {
   const [selectedSaveVersion, setSelectedSaveVersion] = ctxValue;
   const setRef = useRef(false);
 
-  const location = useLocation();
-
-  const setBannerMessage = useSetBannerMessage();
   const walletAddress = useWalletAddress();
 
   const massetName = useSelectedMassetName();
@@ -44,8 +39,6 @@ export const SelectedSaveVersionProvider: FC = ({ children }) => {
   const savingsContracts = massetState?.savingsContracts;
   const v1 = savingsContracts?.v1;
   const v2 = savingsContracts?.v2;
-  const v1Exists = !!v1;
-  const v2Exists = !!v2;
   const v2Current = v2?.current;
   const v1Address = v1?.address;
 
@@ -81,49 +74,6 @@ export const SelectedSaveVersionProvider: FC = ({ children }) => {
     selectedSaveVersion,
     setSelectedSaveVersion,
     v2Current,
-  ]);
-
-  useEffect(() => {
-    let message: BannerMessage | undefined;
-
-    if (!loading && v1Exists) {
-      message = {
-        title: 'SAVE V2 is launching soon! ',
-        emoji: '⚠️',
-        visible: true,
-      };
-
-      if (!hasNoV1Balance) {
-        message.subtitle =
-          'This will require you to migrate your existing funds.';
-      }
-
-      if (v2Exists) {
-        if (location.pathname !== '/save') {
-          message.url = '/save';
-        }
-        if (v2Current) {
-          message.title = 'SAVE V2 has launched!';
-          message.emoji = '🚀';
-          if (!hasNoV1Balance) {
-            message.subtitle =
-              'Migrate your funds now to keep earning interest.';
-          }
-        } else {
-          message.subtitle = 'Safely deposit your savings early now.';
-        }
-      }
-    }
-
-    setBannerMessage(message);
-  }, [
-    loading,
-    location,
-    setBannerMessage,
-    hasNoV1Balance,
-    v1Exists,
-    v2Current,
-    v2Exists,
   ]);
 
   // Remount the provider when the massetName or wallet changes

--- a/src/context/SelectedSaveVersionProvider.tsx
+++ b/src/context/SelectedSaveVersionProvider.tsx
@@ -31,11 +31,10 @@ export const SelectedSaveVersionProvider: FC = ({ children }) => {
   const ctxValue = useState<SaveVersion | undefined>(undefined);
   const [selectedSaveVersion, setSelectedSaveVersion] = ctxValue;
   const setRef = useRef(false);
-
   const walletAddress = useWalletAddress();
-
   const massetName = useSelectedMassetName();
   const massetState = useSelectedMassetState();
+
   const savingsContracts = massetState?.savingsContracts;
   const v1 = savingsContracts?.v1;
   const v2 = savingsContracts?.v2;


### PR DESCRIPTION
## Changelog:
- Show message and disable content when protocol is undergoing recollateralisation.
- Change Tabs on Redeem page
- Remove V2 Migration message

## Screenshots:
| Greyed out content & message 
|---|
| <img width="968" alt="Screenshot 2021-03-16 at 16 28 50" src="https://user-images.githubusercontent.com/19643324/111346749-6f823800-8676-11eb-9ddb-a77316cedb67.png">

| Switch before | Switch after
|---|---|
<img width="647" alt="Screenshot 2021-03-16 at 16 42 33" src="https://user-images.githubusercontent.com/19643324/111346923-9e98a980-8676-11eb-89f2-f54b790e9315.png"> | <img width="691" alt="Screenshot 2021-03-16 at 16 42 49" src="https://user-images.githubusercontent.com/19643324/111346957-a6584e00-8676-11eb-9503-7cc93544df3d.png"> |
