### PR TITLE
Fix overweight redemption

### DIFF
--- a/src/components/pages/Redeem/legacy/BassetOutput.tsx
+++ b/src/components/pages/Redeem/legacy/BassetOutput.tsx
@@ -33,11 +33,10 @@ export const BassetOutput: FC<Props> = ({ address }) => {
   const mode = useRedeemMode();
   const { toggleBassetEnabled, setBassetAmount } = useRedeemDispatch();
 
-  const cannotRedeem = !!(
+  const cannotRedeem =
     mode !== Mode.RedeemMasset &&
     overweightBassets.length > 0 &&
-    overweightBassets.find(b => b !== address)
-  );
+    !overweightBassets.includes(address);
 
   const handleChangeAmount = useCallback<
     NonNullable<ComponentProps<typeof AmountInput>['onChange']>

--- a/src/components/pages/Redeem/legacy/validate.ts
+++ b/src/components/pages/Redeem/legacy/validate.ts
@@ -174,7 +174,7 @@ const redeemMassetValidator: StateValidator = state => {
 /**
  * Validate the basket state for all redemption modes
  */
-const basketValidator: StateValidator = ({ simulation, mode }) => {
+const basketValidator: StateValidator = ({ simulation, mode, bAssets }) => {
   if (!simulation) {
     return [false, Reasons.FetchingData];
   }
@@ -196,7 +196,10 @@ const basketValidator: StateValidator = ({ simulation, mode }) => {
   }
 
   if (mode !== Mode.RedeemMasset) {
-    if (overweightBassets.length > 1) {
+    if (
+      overweightBassets.length > 1 &&
+      overweightBassets.every(b => bAssets[b].enabled)
+    ) {
       return [false, Reasons.MustRedeemOverweightAssets, overweightBassets];
     }
 


### PR DESCRIPTION
- When multiple bAssets are overweight, ensure that they can all be selected for redemption (or redeemMasset can be used)