### PR TITLE
Redirect to Save

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -28,9 +28,9 @@ const List = styled.div`
 `;
 
 const navItems: NavItem[] = [
-  { title: 'Mint', path: '/mint' },
   { title: 'Save', path: '/save' },
   { title: 'Earn', path: '/earn' },
+  { title: 'Mint', path: '/mint' },
   { title: 'Swap', path: '/swap' },
   { title: 'Redeem', path: '/redeem' },
 ];

--- a/src/components/pages/index.tsx
+++ b/src/components/pages/index.tsx
@@ -63,7 +63,7 @@ const MassetButton: FC<{ massetName: MassetName }> = ({ massetName }) => {
           connect();
         }
         setSelectedMassetName(slug as MassetName);
-        history.push(`/${slug}/mint`);
+        history.push(`/${slug}/save`);
       }}
     >
       <StyledTokenIcon symbol={symbol} />


### PR DESCRIPTION
- Redirect to Save on selecting an mAsset
- Reorder the nav items such that Save and Earn come before Mint/Swap/Redeem