### PR TITLE
T&Cs step prior to wallet connection

### DIFF
--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -36,6 +36,7 @@ import { Idle } from '../icons/Idle';
 import { MassetSelector } from '../core/MassetSelector';
 import { LocalStorage } from '../../localStorage';
 import { Navigation } from './Navigation';
+import { useTCModal } from '../../hooks/useTCModal';
 
 const statusWarnings: Record<
   StatusWarnings,
@@ -244,7 +245,7 @@ const StatusWarningsRow: FC = () => {
 
   return (
     <StatusWarningsRowContainer>
-      {warnings.map((warning) => (
+      {warnings.map(warning => (
         <StatusWarning key={warning} error={statusWarnings[warning].error}>
           {statusWarnings[warning].label}
         </StatusWarning>
@@ -261,13 +262,22 @@ const WalletButton: FC = () => {
 
   const truncatedAddress = useTruncatedAddress(account);
   const connect = useConnect();
+  const showTCModal = useTCModal();
+
+  const viewedTerms = LocalStorage.get('tcsViewed');
+
+  const handleClick = (): void => {
+    if (connected && account) {
+      return toggleWallet();
+    }
+    if (!viewedTerms) {
+      return showTCModal();
+    }
+    connect();
+  };
 
   return (
-    <WalletButtonBtn
-      title="Account"
-      onClick={connected && account ? toggleWallet : connect}
-      active={accountOpen}
-    >
+    <WalletButtonBtn title="Account" onClick={handleClick} active={accountOpen}>
       {connected ? (
         <>
           <Idle>
@@ -288,7 +298,7 @@ const TransactionsSpinner: FC = () => {
   const pending = useMemo(
     () =>
       Object.values(transactions).some(
-        (tx) =>
+        tx =>
           tx.status === TransactionStatus.Response ||
           tx.status === TransactionStatus.Sent,
       ),

--- a/src/hooks/useTCModal.tsx
+++ b/src/hooks/useTCModal.tsx
@@ -1,0 +1,99 @@
+import React, { ChangeEventHandler, FC, useCallback } from 'react';
+import { useModal } from 'react-modal-hook';
+import { useToggle } from 'react-use';
+import styled from 'styled-components';
+import { Button, UnstyledButton } from '../components/core/Button';
+
+import { Modal } from '../components/core/Modal';
+import { useConnect } from '../context/OnboardProvider';
+import { LocalStorage } from '../localStorage';
+
+const StyledButton = styled(UnstyledButton)`
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+
+  > * {
+    margin-right: 0.75rem;
+  }
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 2.5rem;
+  max-width: 32rem;
+
+  p {
+    line-height: 1.75rem;
+  }
+
+  > *:not(:last-child) {
+    margin: 0.5rem;
+  }
+
+  button:last-child {
+    margin: 1rem;
+    height: 3rem;
+  }
+`;
+
+const TCAccept: FC<{ onClick: () => void }> = ({ onClick }) => {
+  const [confirm, setConfirm] = useToggle(false);
+  const connect = useConnect();
+
+  const handleAccept = (): void => {
+    connect();
+    onClick();
+    LocalStorage.set('tcsViewed', true);
+  };
+
+  const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+    event => setConfirm(event.target.checked ?? false),
+    [setConfirm],
+  );
+
+  return (
+    <Container>
+      <p>
+        Before connecting your account, please read and accept the&nbsp;
+        <a
+          href="https://docs.mstable.org/appendix/app-usage-terms-and-conditions"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Terms and Conditions
+        </a>
+      </p>
+      <StyledButton onClick={() => setConfirm()}>
+        <input
+          type="checkbox"
+          name="tcs"
+          checked={confirm}
+          value="Terms & Conditions"
+          onChange={handleChange}
+        />
+        I have read and accept
+      </StyledButton>
+      <Button highlighted={confirm} disabled={!confirm} onClick={handleAccept}>
+        Proceed
+      </Button>
+    </Container>
+  );
+};
+
+export const useTCModal = (): (() => void) => {
+  const [showModal, hideModal] = useModal(({ onExited, in: open }) => {
+    return (
+      <Modal
+        title="Terms & Conditions"
+        onExited={onExited}
+        open={open}
+        hideModal={hideModal}
+      >
+        <TCAccept onClick={hideModal} />
+      </Modal>
+    );
+  });
+  return showModal;
+};

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -28,6 +28,7 @@ export interface StorageV3 extends VersionedStorage<3, StorageV2> {
     user?: boolean;
     active?: boolean;
   };
+  tcsViewed?: boolean;
 }
 
 export type AllStorage = { version: number } & Omit<StorageV0, 'version'> &


### PR DESCRIPTION
## Changelog
- Adds T&Cs confirmation prior to wallet connection
- Cache status so that user only see it once

## Screenshots
| S 
|---|
|<img width="570" alt="Screenshot 2021-03-31 at 22 12 48" src="https://user-images.githubusercontent.com/19643324/113212222-64cac400-926e-11eb-990e-1ccf3759c3b0.png"> | 