### PR TITLE
Scale Boost amount

### DIFF
--- a/src/components/rewards/BoostCalculator.tsx
+++ b/src/components/rewards/BoostCalculator.tsx
@@ -200,10 +200,13 @@ export const BoostCalculator: FC<{
   const vMTA = useTokenSubscription(ADDRESSES.vMTA);
   const vMTABalance = vMTA?.balance;
 
+  const defaultInputValue = isImusd
+    ? BigDecimal.parse('100')
+    : BigDecimal.parse('1');
+
   const [vMTAValue, vMTAFormValue, setVmta] = useBigDecimalInput(vMTABalance);
   const [inputValue, inputFormValue, setInput] = useBigDecimalInput(
-    // TODO default to a USD value of $100, 100 mBTC is $$$
-    inputBalance?.simpleRounded !== 0 ? inputBalance : BigDecimal.parse('100'),
+    inputBalance?.simpleRounded !== 0 ? inputBalance : defaultInputValue,
   );
 
   const boost = useMemo(() => {

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -67,21 +67,21 @@ export const calculateBoost = (
   stakingBalance?: BigDecimal,
   vMTABalance?: BigDecimal,
 ): number => {
+  const scaledBalance = (stakingBalance?.simple ?? 0) * priceCoeff;
   if (
     vMTABalance &&
     stakingBalance &&
     vMTABalance.simple > 0 &&
-    stakingBalance.simple > MIN_DEPOSIT
+    scaledBalance >= MIN_DEPOSIT
   ) {
     const unbounded =
       FLOOR +
       (boostCoeff * Math.min(vMTABalance.simple, VMTA_CAP)) /
-        (stakingBalance.simple * priceCoeff) ** EXPONENT;
+        scaledBalance ** EXPONENT;
 
     // bounded
     return Math.min(MAX_BOOST, Math.max(MIN_BOOST, unbounded));
   }
-
   return MIN_BOOST;
 };
 


### PR DESCRIPTION
## Changelog
- Fix #373 by scaling input. Min $1

Can test w/
mBTC vault: `priceCoeff = 58000` -> `0.000017242*58000 = $1` 
mUSD vault: `priceCoeff = 1` -> `1*1 = $1` 