### PR TITLE
Show Pools conditionally

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useMemo } from 'react'
 import styled from 'styled-components'
 import { NavLink } from 'react-router-dom'
 
@@ -6,6 +6,7 @@ import { useSelectedMassetName } from '../../context/SelectedMassetNameProvider'
 import { useCloseAccount, useThemeMode } from '../../context/AppProvider'
 import { colorTheme, ViewportWidth } from '../../theme'
 import { NavigationDropdown, NavItem } from '../core/NavigationDropdown'
+import { useSelectedMassetState } from '../../context/DataProvider/DataProvider'
 
 const List = styled.div`
   display: flex;
@@ -27,15 +28,6 @@ const List = styled.div`
   }
 `
 
-const navItems: NavItem[] = [
-  { title: 'Pools', path: '/pools' },
-  { title: 'Save', path: '/save' },
-  { title: 'Mint', path: '/mint' },
-  { title: 'Swap', path: '/swap' },
-  { title: 'Redeem', path: '/redeem' },
-  { title: 'Stats', path: '/stats' },
-]
-
 const StyledNavLink = styled(NavLink)`
   margin: 0 0.5rem;
   position: relative;
@@ -49,6 +41,19 @@ export const Navigation: FC = () => {
   const collapseWallet = useCloseAccount()
   const massetName = useSelectedMassetName()
   const themeMode = useThemeMode()
+  const massetState = useSelectedMassetState()
+  const hasFeederPools = massetState?.hasFeederPools
+
+  const navItems = useMemo<NavItem[]>(() => {
+    return [
+      ...(hasFeederPools ? [{ title: 'Pools', path: '/pools' }] : []),
+      { title: 'Save', path: '/save' },
+      { title: 'Mint', path: '/mint' },
+      { title: 'Swap', path: '/swap' },
+      { title: 'Redeem', path: '/redeem' },
+      { title: 'Stats', path: '/stats' },
+    ]
+  }, [hasFeederPools])
 
   return (
     <nav>

--- a/src/components/pages/Pools/index.tsx
+++ b/src/components/pages/Pools/index.tsx
@@ -14,6 +14,7 @@ import { useSelectedMassetState } from '../../../context/DataProvider/DataProvid
 import { PoolType } from './types'
 import { formatMassetName, useSelectedMassetName } from '../../../context/SelectedMassetNameProvider'
 import { MassetName } from '../../../types'
+import { useNetwork } from '../../../context/NetworkProvider'
 
 interface CustomAssetCardProps {
   isCustomAssetCard: boolean
@@ -144,8 +145,22 @@ const customPoolCard = (massetName: MassetName): CustomAssetCardProps => {
   }
 }
 
+const customNoPoolsCard = (massetName: MassetName, protocolName: string): CustomAssetCardProps => ({
+  isCustomAssetCard: true,
+  key: 'noPools',
+  title: 'No Pools Available',
+  color: '#eee',
+  url: '/',
+  component: (
+    <CustomContent>
+      There are no pools available for {formatMassetName(massetName)} on {protocolName} at this time
+    </CustomContent>
+  ),
+})
+
 const PoolsContent: FC = () => {
-  const { feederPools } = useSelectedMassetState() as MassetState
+  const { feederPools, hasFeederPools } = useSelectedMassetState() as MassetState
+  const network = useNetwork()
   const massetName = useSelectedMassetName()
   const pools = useMemo(
     () =>
@@ -163,11 +178,13 @@ const PoolsContent: FC = () => {
         },
         {
           user: [],
-          active: [customEarnCard(massetName), customPoolCard(massetName)],
+          active: hasFeederPools
+            ? [customEarnCard(massetName), customPoolCard(massetName)]
+            : [customNoPoolsCard(massetName, network.protocolName)],
           deprecated: [],
         },
       ),
-    [feederPools, massetName],
+    [feederPools, massetName, hasFeederPools, network.protocolName],
   )
 
   const [numPoolsVisible, setNumPoolsVisible] = useState({

--- a/src/context/AccountProvider.tsx
+++ b/src/context/AccountProvider.tsx
@@ -209,7 +209,9 @@ const OnboardProvider: FC<{
       try {
         const selected = await onboard.walletSelect(walletName)
         if (selected) {
-          await onboard.walletCheck()
+          const checked = await onboard.walletCheck()
+          if (!checked) return
+
           addInfoNotification(
             `Connected${typeof walletName === 'string' ? ` with ${walletName}` : ''}`,
             `${network.protocolName} (${network.chainName})`,

--- a/src/context/DataProvider/transformRawData.ts
+++ b/src/context/DataProvider/transformRawData.ts
@@ -335,6 +335,7 @@ const transformMassetData = (
     feeRate: BigNumber.from(feeRate),
     redemptionFeeRate: BigNumber.from(redemptionFeeRate),
     feederPools,
+    hasFeederPools: Object.keys(feederPools).length > 0,
     savingsContracts: {
       v1: savingsContractV1 ? transformSavingsContractV1(savingsContractV1, tokens, address, false) : undefined,
       v2: transformSavingsContractV2({ ...savingsContractV2, boostedSavingsVaults: saveVaults }, tokens, address, true),

--- a/src/context/DataProvider/types.ts
+++ b/src/context/DataProvider/types.ts
@@ -68,6 +68,7 @@ export interface MassetState {
   removedBassets: { [address: string]: SubscribedToken }
   blacklistedBassets: string[]
   collateralisationRatio?: BigNumber
+  hasFeederPools: boolean
   failed: boolean
   feeRate: BigNumber
   forgeValidator: string


### PR DESCRIPTION
_View when on Pools, switching from mainnet to another chain_

![Screenshot 2021-04-22 at 15 21 44](https://user-images.githubusercontent.com/5450382/115725404-1a76c780-a382-11eb-9170-24d855c6d5ec.png)

- Show pools in the nav items when there are pools defined for the current chain/mAsset
- Add a "No pools" card if on the pools view and no pools exist on that chain/mAsset
- Bugfix: Ensure the wallet connection is checked before sending a notification
