### PR TITLE
Fix mismatching providers

### DIFF
--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 
 import { useAccountOpen, useCloseAccount, useThemeMode, useToggleThemeMode, useToggleWallet } from '../../context/AppProvider'
-import { useConnect, useWallet, useWalletAddress, useConnected } from '../../context/AccountProvider'
+import { getNetwork, useChainIdCtx } from '../../context/NetworkProvider'
+import { useConnect, useWallet, useWalletAddress, useConnected, useInjectedChainIdCtx } from '../../context/AccountProvider'
 import { useTransactionsState } from '../../context/TransactionsProvider'
 
 import { Color, ViewportWidth } from '../../theme'
@@ -54,12 +55,11 @@ const AccountButton = styled(UnstyledButton)<{ active: boolean }>`
   border-radius: 1rem;
   cursor: pointer;
   display: flex;
-  font-weight: bold;
+  font-weight: 600;
   height: 2rem;
   justify-content: space-between;
   line-height: 100%;
   padding: 0.25rem 0.8rem;
-  text-transform: uppercase;
   transition: all 0.3s ease;
 
   > * {
@@ -193,11 +193,24 @@ const CloseAccount: FC = () => {
   )
 }
 
+const WrongNetwork = styled.div`
+  color: red;
+  > :first-child {
+    margin-bottom: 0.25rem;
+  }
+  > :last-child {
+    font-weight: normal;
+  }
+`
+
 const WalletButton: FC = () => {
   const accountOpen = useAccountOpen()
   const toggleWallet = useToggleWallet()
   const connected = useConnected()
   const account = useWalletAddress()
+  const [injectedChainId] = useInjectedChainIdCtx()
+  const [chainId] = useChainIdCtx()
+  const injectedNetwork = useMemo(() => (injectedChainId ? getNetwork(injectedChainId) : undefined), [injectedChainId])
 
   const connect = useConnect()
   const showTCModal = useTCModal()
@@ -216,7 +229,20 @@ const WalletButton: FC = () => {
 
   return (
     <WalletButtonBtn title="Account" onClick={handleClick} active={accountOpen}>
-      {connected ? (
+      {injectedChainId && chainId !== injectedChainId ? (
+        <>
+          <div>
+            <WalletIcon />
+          </div>
+          <WrongNetwork>
+            <div>
+              {/* eslint-disable-next-line jsx-a11y/accessible-emoji */}
+              <span>⚠️</span> Wrong network
+            </div>
+            <div>{injectedNetwork ? `${injectedNetwork.protocolName} (${injectedNetwork.chainName})` : `Chain ID ${injectedChainId}`}</div>
+          </WrongNetwork>
+        </>
+      ) : connected ? (
         <>
           <Idle>
             <WalletIcon />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -4,9 +4,14 @@ import reset from 'styled-reset'
 import { useLocation } from 'react-router-dom'
 import { TransitionGroup } from 'react-transition-group'
 import { ModalProvider } from 'react-modal-hook'
-
+import { usePrevious } from 'react-use'
 import { getUnixTime } from 'date-fns'
 import { BigNumber } from 'ethers'
+
+import { Networks, useChainIdCtx, useNetwork } from '../../context/NetworkProvider'
+import { useSelectedMassetName } from '../../context/SelectedMassetNameProvider'
+import { useSelectedMassetState } from '../../context/DataProvider/DataProvider'
+
 import { ReactTooltip, Tooltip } from '../core/ReactTooltip'
 import { Footer } from './Footer'
 import { Account } from './Account'
@@ -15,24 +20,18 @@ import { Background } from './Background'
 import { AppBar } from './AppBar'
 import { Toasts } from './Toasts'
 import { Color, ViewportWidth } from '../../theme'
-import { useSelectedMassetName } from '../../context/SelectedMassetNameProvider'
-import { useSelectedMassetState } from '../../context/DataProvider/DataProvider'
 import { BigDecimal } from '../../web3/BigDecimal'
 import { SCALE } from '../../constants'
 import { MessageHandler } from './MessageHandler'
-import { Networks, useNetwork } from '../../context/NetworkProvider'
 
 const Main = styled.main<{ marginTop?: boolean }>`
   margin-top: ${({ marginTop }) => marginTop && `2rem`};
+  padding: 0 1rem;
+  min-height: 50vh;
 
   @media (min-width: ${ViewportWidth.s}) {
     padding: 1rem;
   }
-`
-
-const BackgroundContainer = styled.div`
-  padding: 0 1rem;
-  min-height: 50vh;
 `
 
 const GlobalStyle = createGlobalStyle`
@@ -220,6 +219,8 @@ export const Layout: FC = ({ children }) => {
   const accountOpen = useAccountOpen()
   const { pathname } = useLocation()
   const home = pathname === '/'
+  const [chainId] = useChainIdCtx()
+  const prevChainId = usePrevious(chainId)
 
   // Message
   const [bannerMessage, setBannerMessage] = useBannerMessage()
@@ -274,15 +275,7 @@ export const Layout: FC = ({ children }) => {
     <ModalProvider rootComponent={TransitionGroup}>
       <Background home={home} accountOpen={accountOpen} />
       <HeaderGroup home={home} />
-      <Container>
-        {accountOpen ? (
-          <Account />
-        ) : (
-          <Main marginTop={home}>
-            <BackgroundContainer>{children}</BackgroundContainer>
-          </Main>
-        )}
-      </Container>
+      <Container>{accountOpen ? <Account /> : <Main marginTop={home}>{prevChainId === chainId ? children : null}</Main>}</Container>
       <Footer />
       <Toasts />
       <Tooltip tip="" hideIcon />

--- a/src/context/NetworkProvider.tsx
+++ b/src/context/NetworkProvider.tsx
@@ -317,7 +317,6 @@ const MATIC_MUMBAI: MaticMumbai = {
     feeders: 'https://api.thegraph.com/subgraphs/name/mstable/mstable-feeder-pools-mumbai',
     // This is for mainnet, no subgraph available for Mumbai
     blocks: 'https://api.thegraph.com/subgraphs/name/elkfinance/matic-blocks',
-    ecosystem: 'https://api.thegraph.com/subgraphs/name/mstable/mstable-ecosystem', // fixme remove
   },
   addresses: {
     MTA: '0x273bc479e5c21caa15aa8538decbf310981d14c0', // Mainnet

--- a/src/hooks/useEstimatedMintOutput.ts
+++ b/src/hooks/useEstimatedMintOutput.ts
@@ -19,8 +19,7 @@ export const useEstimatedMintOutput = (contract?: MintableContract, inputValues?
 
   const [update] = useDebounce(
     () => {
-      if (!inputValues) return
-      if (!contract) return setEstimatedOutputAmount.fetching()
+      if (!inputValues || !contract) return
 
       const touched = Object.values(inputValues).filter(v => v.touched)
 

--- a/src/hooks/useEstimatedOutput.ts
+++ b/src/hooks/useEstimatedOutput.ts
@@ -146,10 +146,7 @@ export const useEstimatedOutput = (inputValue?: BigDecimalInputValue, outputValu
 
   const [update] = useDebounce(
     () => {
-      if (!inputValue || !outputValue) return
-      if (shouldSkip) return {}
-
-      if (!contract) return setEstimatedOutputAmount.fetching()
+      if (!inputValue || !outputValue || shouldSkip || !contract) return
 
       const { address: inputAddress, amount: inputAmount } = inputValue
       const { address: outputAddress, decimals: outputDecimals } = outputValue

--- a/src/hooks/useEstimatedRedeemOutput.ts
+++ b/src/hooks/useEstimatedRedeemOutput.ts
@@ -19,8 +19,7 @@ export const useEstimatedRedeemOutput = (contract?: RedeemableContract, inputVal
   // Get the swap output with a throttle so it's not called too often
   const [update] = useDebounce(
     () => {
-      if (!inputValues) return
-      if (!contract) return setEstimatedOutputAmount.fetching()
+      if (!inputValues || !contract) return
 
       const touched = Object.values(inputValues).filter(v => v.touched)
 


### PR DESCRIPTION
- Handle the injected provider being set to a different chain than the selected chain
- Show a warning in the UI
- Unset the signer and use the non-injected provider
- Remount components on chain change
- Fix output estimate fetch state