### PR TITLE
Validate gas limit, adjust gas limit for Polygon

### DIFF
--- a/src/components/pages/Save/index.tsx
+++ b/src/components/pages/Save/index.tsx
@@ -92,7 +92,7 @@ export const Save: FC = () => {
           <Content>
             {showMigrationView ? <SaveMigration /> : <SaveV2 />}
             <Sidebar>
-              {massetName === 'musd' && (
+              {chainId === ChainIds.EthereumMainnet && massetName === 'musd' && (
                 <ButtonPanel>{massetName === 'musd' ? <ToggleSave /> : <div />}</ButtonPanel>
               )}
               <InfoBox>

--- a/src/components/stats/DailyApys.tsx
+++ b/src/components/stats/DailyApys.tsx
@@ -56,7 +56,7 @@ const DailyApysChart: FC<{
   const savingsContractState = useSelectedSavingsContractState()
   const dailyApys = useDailyApysForBlockTimes(savingsContractState?.address, blockTimes)
 
-  if (dailyApys.some(value => value.dailyAPY === 0 || value.dailyAPY > 1000)) {
+  if (dailyApys.some(value => value.dailyAPY > 1000) || dailyApys.every(value => value.dailyAPY === 0)) {
     return <NoData className={className}>No data available yet</NoData>
   }
 

--- a/src/web3/TransactionManifest.ts
+++ b/src/web3/TransactionManifest.ts
@@ -4,9 +4,9 @@ import { ErrorCode } from '@ethersproject/logger'
 
 import { Instances, Interfaces, Purpose } from '../types'
 
-const calculateGasMargin = (value: BigNumber): BigNumber => {
-  const GAS_MARGIN = BigNumber.from(1000)
-  const offset = value.mul(GAS_MARGIN).div(BigNumber.from(10000))
+const calculateGasMargin = (value: BigNumber, margin = 1000): BigNumber => {
+  const gasMargin = BigNumber.from(margin)
+  const offset = value.mul(gasMargin).div(BigNumber.from(10000))
   return value.add(offset)
 }
 
@@ -82,10 +82,10 @@ export class TransactionManifest<TIface extends Interfaces, TFn extends keyof In
     return response
   }
 
-  async estimate(): Promise<BigNumber> {
+  async estimate(margin?: number): Promise<BigNumber> {
     try {
       const gasLimit = (await this.contract.estimateGas[this.fn](...this.args)) as BigNumber
-      return calculateGasMargin(gasLimit)
+      return calculateGasMargin(gasLimit, margin)
     } catch (error) {
       // Ethers v5 error handling:
       // - Error revert reasons can be nested


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5450382/116043637-358e5380-a670-11eb-8704-98bb5e903769.png)

- Make the gas margin configurable, and use 100% margin for Polygon (as opposed to 2m cap, which is sometimes not refunded)
- Validate insufficient balance to pay for gas
- Show the native token balance/value in the gas station
- Add insufficient balance for gas to form validation

**Misc**  
- Show the daily APY chart when there are some reasonable values
- Show the save version for Eth mainnet only