### PR TITLE
Fix Save page - do not calculate when wallet is not connected

### DIFF
--- a/src/components/pages/Save/v2/useSaveOutput.ts
+++ b/src/components/pages/Save/v2/useSaveOutput.ts
@@ -95,7 +95,7 @@ export const useSaveOutput = (route?: SaveRoutes, inputAddress?: string, inputAm
 
   const [update] = useDebounce(
     () => {
-      if (!inputAmountSerialized || !inputAddress) return setSaveOutput.value()
+      if (!inputAmountSerialized || !inputAddress || !signer) return setSaveOutput.value()
 
       const _inputAmount = BigDecimal.fromJSON(inputAmountSerialized)
 


### PR DESCRIPTION
Hi guys,

This is a small fix to prevent **"Cannot read property 'call' of null"** error on Save page, when no wallet is connected.

Best,
Tamas

![Screenshot 2021-05-06 at 17 27 06 (2)](https://user-images.githubusercontent.com/1397179/117462795-4a5fc680-af4f-11eb-8658-9b8ce590fea5.png)
