### PR TITLE
Boost tweak

### DIFF
--- a/src/__tests__/boost.test.ts
+++ b/src/__tests__/boost.test.ts
@@ -85,7 +85,7 @@ describe('test boost calculations', () => {
       {
         amount: BigDecimal.parse('1.724137931'), // $10k
         mta: BigDecimal.parse('175'), // 175 mta
-        expected: '1.27',
+        expected: '1.22',
       },
       {
         amount: BigDecimal.parse('10'), // $10
@@ -119,7 +119,7 @@ describe('test boost calculations', () => {
       {
         amount: BigDecimal.parse('3000'), // $3k
         mta: BigDecimal.parse('100'), // 100 mta
-        expected: '1.44',
+        expected: '1.39',
       },
       {
         amount: BigDecimal.parse('10'), // $10
@@ -129,12 +129,12 @@ describe('test boost calculations', () => {
       {
         amount: BigDecimal.parse('30000'), // $30k
         mta: BigDecimal.parse('100'),
-        expected: '1.06',
+        expected: '1.01',
       },
       {
         amount: BigDecimal.parse('100000'), // $100k
         mta: BigDecimal.parse('5000'),
-        expected: '2.01',
+        expected: '1.96',
       },
     ]
 
@@ -164,7 +164,7 @@ describe('test boost calculations', () => {
       {
         amount: BigDecimal.parse('0.1724137931'), // $10k
         mta: BigDecimal.parse('100'), // 100 mta
-        expected: '1.15',
+        expected: '1.10',
       },
       {
         amount: BigDecimal.parse('0.0001724137931'), // $10
@@ -174,7 +174,7 @@ describe('test boost calculations', () => {
       {
         amount: BigDecimal.parse('1.724137931'), // $100k
         mta: BigDecimal.parse('1000'),
-        expected: '1.20',
+        expected: '1.15',
       },
     ]
 

--- a/src/context/NetworkProvider.tsx
+++ b/src/context/NetworkProvider.tsx
@@ -338,7 +338,7 @@ export const getNetwork = (chainId: ChainIds | 0): Extract<AllNetworks, { chainI
       return MATIC_MUMBAI
 
     default:
-      throw new Error('Unsupported chain ID')
+      return ETH_MAINNET
   }
 }
 

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -40,17 +40,17 @@ export const MIN_DEPOSIT = 1
 
 export const calculateVMTAForMaxBoost = (stakingBalance: BigDecimal, boostCoeff: number, priceCoeff: number): number => {
   const scaledBalance = stakingBalance.simple * priceCoeff
-  const x = MAX_BOOST - FLOOR
+  const x = MAX_BOOST - FLOOR * 0.95
   const y = scaledBalance ** EXPONENT
   const unbounded = (x * y) / boostCoeff
   return Math.min(unbounded, VMTA_CAP)
 }
 
+// 0.95 + c * min(voting_weight, f) / deposit^(7/8)
 export const calculateBoost = (boostCoeff: number, priceCoeff: number, stakingBalance?: BigDecimal, vMTABalance?: BigDecimal): number => {
   const scaledBalance = (stakingBalance?.simple ?? 0) * priceCoeff
   if (vMTABalance && stakingBalance && vMTABalance.simple > 0 && scaledBalance >= MIN_DEPOSIT) {
-    const unbounded = FLOOR + (boostCoeff * Math.min(vMTABalance.simple, VMTA_CAP)) / scaledBalance ** EXPONENT
-    // bounded
+    const unbounded = FLOOR * 0.95 + (boostCoeff * Math.min(vMTABalance.simple, VMTA_CAP)) / scaledBalance ** EXPONENT
     return Math.min(MAX_BOOST, Math.max(MIN_BOOST, unbounded))
   }
   return MIN_BOOST


### PR DESCRIPTION
## Changelog
- Calculation for user boost was very slightly out due to `FLOOR * 0.95` in formula & not `FLOOR`
- Update tests accordingly
- Fallback to use Eth RPC if chain is unknown to prevent crash. Will come up with a better solution