### PR TITLE
Hide poke boost on zero boost

### DIFF
--- a/src/components/core/PokeBoost.tsx
+++ b/src/components/core/PokeBoost.tsx
@@ -107,7 +107,8 @@ export const PokeBoost: FC<Props> = ({ apy, vault }) => {
   const userBoost = useCalculateUserBoost(vault)
   const rewardStreams = useRewardStreams()
 
-  const showWarning = (account?.boostMultiplier ?? 0) < (userBoost ?? 0) && !!account?.boostMultiplier
+  // FIXME: - Replace account?.boostMultiplier !== 1 with catch to show boost director
+  const showWarning = (account?.boostMultiplier ?? 0) < (userBoost ?? 0) && account?.boostMultiplier !== 1 && !!account?.boostMultiplier
   const message = isImusd ? 'Claim rewards to update your reward rate.' : 'Poke the contract or claim rewards to update your reward rate.'
 
   if (!showWarning) return null


### PR DESCRIPTION
## Changelog
- If user has exceeded their # of boosted pools, their boost multiplier is 1 but they will continue to see the 'poke boost' warning. This is a temp fix to hide that so that users don't keep spamming claim or poke in the hope that their boost updates.