### PR TITLE
Improve clarity of rewards

### DIFF
--- a/src/components/core/TransitionCard.tsx
+++ b/src/components/core/TransitionCard.tsx
@@ -22,7 +22,6 @@ export const CardButton = styled(UnstyledButton)<{
   }
 
   span {
-    ${({ theme }) => theme.mixins.numeric};
     font-size: 1.125rem;
   }
 

--- a/src/components/pages/Pools/Detail/ClaimGraph.tsx
+++ b/src/components/pages/Pools/Detail/ClaimGraph.tsx
@@ -69,14 +69,14 @@ interface Chart {
   }[]
 }
 
-export const ClaimGraph: FC<{ showPreview?: boolean }> = ({ showPreview }) => {
+export const ClaimGraph: FC = () => {
   const rewardStreams = useRewardStreams()
 
   const chart = useMemo<Chart>(() => {
     if (!rewardStreams) return { maxY: 0, groups: [] }
 
     // Filter for selected types
-    const filtered = showPreview ? rewardStreams.chartData : rewardStreams.chartData.filter(datum => !datum[StreamType.LockedPreview])
+    const filtered = rewardStreams.chartData
 
     // Group into ranges
     const ranges = filtered
@@ -130,7 +130,7 @@ export const ClaimGraph: FC<{ showPreview?: boolean }> = ({ showPreview }) => {
         })
         .filter(group => group.data.length > 1),
     }
-  }, [rewardStreams, showPreview])
+  }, [rewardStreams])
 
   return rewardStreams ? (
     <ChartContainer key={chart.groups.length}>
@@ -192,7 +192,7 @@ export const ClaimGraph: FC<{ showPreview?: boolean }> = ({ showPreview }) => {
                 <Label position="insideTopLeft" value="Next unlock" fontSize={14} dy={-20} dx={-6} />
               </ReferenceLine>
             )}
-            {rewardStreams && showPreview && (
+            {rewardStreams && (
               <ReferenceLine x={rewardStreams.previewStream.start} stroke={Color.greyTransparent}>
                 <Label position="insideTopLeft" value="New unlock" fontSize={14} />
               </ReferenceLine>

--- a/src/components/pages/Pools/Detail/PoolOverview.tsx
+++ b/src/components/pages/Pools/Detail/PoolOverview.tsx
@@ -14,6 +14,7 @@ import { BoostCalculator } from '../../../rewards/BoostCalculator'
 import { BoostedSavingsVaultState } from '../../../../context/DataProvider/types'
 import { TransitionCard, CardContainer as Container, CardButton as Button } from '../../../core/TransitionCard'
 import { PokeBoost } from '../../../core/PokeBoost'
+import { Tooltip } from '../../../core/ReactTooltip'
 
 enum Selection {
   Stake = 'stake',
@@ -67,7 +68,8 @@ export const PoolOverview: FC = () => {
   const userAmount = token.balance?.simple ?? 0
   const userStakedAmount = vault.account?.rawBalance.simple ?? 0
 
-  const totalEarned = rewardStreams?.amounts.earned.total ?? 0
+  const totalEarned =
+    (rewardStreams?.amounts.earned.unlocked ?? 0) + (rewardStreams?.amounts.previewLocked ?? 0) + (rewardStreams?.amounts.locked ?? 0)
   const totalLocked = rewardStreams?.amounts.locked ?? 0
   const showLiquidityMessage = totalEarned === 0 && totalLocked === 0
 
@@ -97,7 +99,10 @@ export const PoolOverview: FC = () => {
           </Button>
           <Button active={selection === Rewards} onClick={() => handleSelection(Rewards)}>
             <h3>Rewards</h3>
-            <CountUp end={totalEarned} /> MTA
+            <div>
+              <CountUp end={totalEarned} suffix=" MTA" />
+              <Tooltip tip="MTA rewards unlock over time" />
+            </div>
           </Button>
         </Container>
       </TransitionCard>

--- a/src/components/pages/Save/v2/SaveOverview.tsx
+++ b/src/components/pages/Save/v2/SaveOverview.tsx
@@ -21,6 +21,7 @@ import { SavePosition } from './SavePosition'
 import { OnboardingBanner } from './OnboardingBanner'
 import { ThemedSkeleton } from '../../../core/ThemedSkeleton'
 import { PokeBoost } from '../../../core/PokeBoost'
+import { Tooltip } from '../../../core/ReactTooltip'
 
 enum Selection {
   Balance = 'Balance',
@@ -163,7 +164,9 @@ export const SaveOverview: FC = () => {
 
   const userBoost = useCalculateUserBoost(boostedSavingsVault)
   const apy = useSaveVaultAPY(saveToken?.symbol, userBoost)
-  const totalEarned = rewardStreams?.amounts.earned.total ?? 0
+
+  const totalEarned =
+    (rewardStreams?.amounts.earned.unlocked ?? 0) + (rewardStreams?.amounts.previewLocked ?? 0) + (rewardStreams?.amounts.locked ?? 0)
 
   const userBalance = useMemo(() => {
     if (selectedSaveVersion === 1) return saveV1Balance?.balance
@@ -216,7 +219,10 @@ export const SaveOverview: FC = () => {
           {!!boostedSavingsVault && (
             <Button active={selection === Rewards} onClick={() => handleSelection(Rewards)}>
               <h3>Rewards</h3>
-              <CountUp end={totalEarned} /> MTA
+              <div>
+                <CountUp end={totalEarned} suffix=" MTA" />
+                <Tooltip tip="MTA rewards unlock over time" />
+              </div>
             </Button>
           )}
         </TransitionContainer>


### PR DESCRIPTION
## Issue:
- Some users were getting confused as to where their rewards went after they deposited more to the Vault

## Changelog:
- Adjust Rewards title to show total reward earned (including new lock amount)
- Remove default state & make the preview state the default 
- Add tooltip to MTA 

## Screenshots:
<img width="985" alt="Screenshot 2021-06-08 at 14 46 18" src="https://user-images.githubusercontent.com/19643324/121206724-9d8ba880-c870-11eb-9cc1-524393fbb741.png">
