### PR TITLE
Rewards Table view toggle

### DIFF
--- a/src/components/pages/Pools/Detail/UserRewards.tsx
+++ b/src/components/pages/Pools/Detail/UserRewards.tsx
@@ -3,6 +3,8 @@ import Skeleton from 'react-loading-skeleton'
 import styled from 'styled-components'
 import { BoostedSavingsVault__factory, BoostedSavingsVault } from '@mstable/protocol/types/generated'
 
+import { format, fromUnixTime } from 'date-fns'
+import { useToggle } from 'react-use'
 import { StreamType, useRewardStreams } from '../../../../context/RewardStreamsProvider'
 import { usePropose } from '../../../../context/TransactionsProvider'
 import { useIsMasquerading, useSigner } from '../../../../context/AccountProvider'
@@ -16,6 +18,8 @@ import { CountUp } from '../../../core/CountUp'
 import { useSelectedFeederPoolVaultContract } from '../FeederPoolProvider'
 import { rewardsColorMapping } from '../constants'
 import { ClaimGraph } from './ClaimGraph'
+import { Table, TableCell, TableRow } from '../../../core/Table'
+import { Button } from '../../../core/Button'
 
 const useSelectedSaveVaultContract = (): BoostedSavingsVault | undefined => {
   const signer = useSigner()
@@ -113,39 +117,41 @@ const ClaimButton = styled(SendButton)<{ visible: boolean }>`
 `}
 `
 
+const ToggleViewButton = styled(Button)`
+  border-radius: 0.75rem;
+`
+
 const ClaimContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
 
   > * {
-    flex-basis: calc(50% - 0.5rem);
     height: 2.75rem;
   }
 
   > div {
     width: 100%;
+    margin-bottom: 0.5rem;
   }
 
   button {
     height: 2.75rem;
     min-width: 11rem;
-    margin-bottom: 0.5rem;
     width: 100%;
-  }
-
-  @media (min-width: ${({ theme }) => theme.viewportWidth.m}) {
-    button {
-      margin-bottom: 0;
-    }
   }
 
   @media (min-width: ${({ theme }) => theme.viewportWidth.l}) {
     align-items: flex-end;
+    flex-direction: row;
 
     > div {
       width: calc(33% - 0.5rem);
+    }
+
+    > div:not(:last-child) {
+      margin-right: 1rem;
     }
   }
 `
@@ -173,6 +179,13 @@ const GraphAndValues = styled.div`
     > div:first-child {
       display: inherit;
     }
+  }
+`
+
+const CustomTable = styled(Table)`
+  tbody span {
+    font-weight: normal !important;
+    margin-left: 0.5rem;
   }
 `
 
@@ -242,6 +255,7 @@ export const UserRewards: FC = () => {
   const feederVault = useSelectedFeederPoolVaultContract()
   const saveVault = useSelectedSaveVaultContract()
   const [selectedSaveVersion] = useSelectedSaveVersion()
+  const [showLockTable, toggleLockTable] = useToggle(true)
 
   const propose = usePropose()
   const contract = feederVault ?? saveVault
@@ -253,30 +267,51 @@ export const UserRewards: FC = () => {
     <RewardsCard>
       <div>
         {showGraph ? (
-          <GraphAndValues>
-            <ClaimGraph />
-            <RewardValues>
-              <RewardValue
-                title="Unclaimed"
-                label="Sent to you now"
-                value={rewardStreams?.amounts.earned.unlocked}
-                streamType={StreamType.Earned}
-              />
-              <RewardValue
-                title="Unlocked"
-                label={(rewardStreams?.amounts.unlocked ?? 0) > 0 ? `Sent to you now` : `From previous claims`}
-                value={rewardStreams?.amounts.unlocked}
-                streamType={StreamType.Unlocked}
-              />
-              <RewardValue
-                title="Locked"
-                label="From previous earnings"
-                value={(rewardStreams?.amounts.previewLocked ?? 0) + (rewardStreams?.amounts.locked ?? 0)}
-                streamType={StreamType.Locked}
-              />
-            </RewardValues>
-            {!isMasquerading && (
-              <ClaimContainer>
+          <>
+            {showLockTable ? (
+              <GraphAndValues>
+                <ClaimGraph />
+                <RewardValues>
+                  <RewardValue
+                    title="Unclaimed"
+                    label="Sent to you now"
+                    value={rewardStreams?.amounts.earned.unlocked}
+                    streamType={StreamType.Earned}
+                  />
+                  <RewardValue
+                    title="Unlocked"
+                    label={(rewardStreams?.amounts.unlocked ?? 0) > 0 ? `Sent to you now` : `From previous claims`}
+                    value={rewardStreams?.amounts.unlocked}
+                    streamType={StreamType.Unlocked}
+                  />
+                  <RewardValue
+                    title="Locked"
+                    label="From previous earnings"
+                    value={(rewardStreams?.amounts.previewLocked ?? 0) + (rewardStreams?.amounts.locked ?? 0)}
+                    streamType={StreamType.Locked}
+                  />
+                </RewardValues>
+              </GraphAndValues>
+            ) : (
+              <CustomTable headerTitles={['Date unlocked', 'Amount']}>
+                {rewardStreams?.lockedStreams?.map(stream => (
+                  <TableRow key={stream.start} buttonTitle="View">
+                    <TableCell width={75}>
+                      {format(fromUnixTime(stream.finish), 'dd.MM.yy')}
+                      <span>&nbsp;{format(fromUnixTime(stream.finish), 'HH:mm')}</span>
+                    </TableCell>
+                    <TableCell>
+                      <p>{(stream.amount?.[2] ?? stream.amount?.[3])?.toFixed(2)} MTA</p>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </CustomTable>
+            )}
+            <ClaimContainer>
+              <div>
+                <ToggleViewButton onClick={toggleLockTable}>{showLockTable ? `View Table` : `View Chart`}</ToggleViewButton>
+              </div>
+              {!isMasquerading && (
                 <ClaimButton
                   visible
                   valid={!!canClaim}
@@ -292,9 +327,9 @@ export const UserRewards: FC = () => {
                     }
                   }}
                 />
-              </ClaimContainer>
-            )}
-          </GraphAndValues>
+              )}
+            </ClaimContainer>
+          </>
         ) : (
           <EmptyState>
             <h3>No rewards to claim</h3>

--- a/src/context/RewardStreamsProvider.tsx
+++ b/src/context/RewardStreamsProvider.tsx
@@ -43,6 +43,7 @@ export interface RewardStreams {
   nextUnlock?: number
   chartData: ChartData
   previewStream: Stream
+  lockedStreams: Stream[]
 }
 
 const nowUnix = getUnixTime(Date.now())
@@ -261,7 +262,8 @@ export const RewardStreamsProvider: FC<{
         currentTime,
         nextUnlock: lockedStreams[0]?.start,
         previewStream,
-      }
+        lockedStreams: [...lockedStreams, previewStream],
+      } as RewardStreams
     }
   }, [currentTime, vault])
 


### PR DESCRIPTION
## Changelog:
- Adds table view option on Rewards to view locked MTA

When there are lots of data points on the chart, the data becomes hard to read on small timeframes - this gives the user an alternative view & allows for easy copy/pasting of data if needed.

## Screenshots:
<img width="945" alt="Screenshot 2021-06-11 at 11 02 43" src="https://user-images.githubusercontent.com/19643324/121670262-1ffcae00-caa5-11eb-9751-48c6ee611ae6.png">
