### PR TITLE
Avoid caching metrics

### DIFF
--- a/src/components/pages/Pools/cards/AssetCard.tsx
+++ b/src/components/pages/Pools/cards/AssetCard.tsx
@@ -129,7 +129,7 @@ const PoolStats: FC<{ isLarge?: boolean; address: string }> = ({ isLarge = false
       return swapped.add(minted).add(redeemed)
     }
     return BigDecimal.ZERO
-  }, [fpMetrics.data])
+  }, [fpMetrics])
 
   return (
     <StatsContainer isLarge={isLarge}>

--- a/src/context/ApolloProvider.tsx
+++ b/src/context/ApolloProvider.tsx
@@ -24,6 +24,9 @@ const cache = new InMemoryCache({
     Token: {
       keyFields: false,
     },
+    Metric: {
+      keyFields: false,
+    },
     Query: {
       fields: {
         tokens: {


### PR DESCRIPTION
- Avoid caching metrics to prevent ID conflicts
- Fixes an issue where pool volume was not reported correctly